### PR TITLE
TTT: Fixed not being able to shoot a weapon when equipped while being held by a magneto stick

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -123,6 +123,10 @@ function SWEP:Reset(keep_velocity)
       if (not keep_velocity) and (no_throw:GetBool() or self.EntHolding:GetClass() == "prop_ragdoll") then
          KillVelocity(self.EntHolding)
       end
+
+      if self.EntHolding:IsWeapon() then
+         hook.Remove("WeaponEquip", "TTT_WeaponOwnerFix"..self:EntIndex())
+      end
    end
 
    self.dt.carried_rag = nil
@@ -399,7 +403,19 @@ function SWEP:Pickup()
 
          self.Constr = constraint.Weld(self.CarryHack, self.EntHolding, 0, bone, max_force, true)
 
-
+         if ent:IsWeapon() then
+            -- If the player picks up a weapon while it's being held with a magento stick, the owner won't be set properly.
+            hook.Add("WeaponEquip", "TTT_WeaponOwnerFix"..self:EntIndex(), function(wep)
+               if not IsValid(self) then return end
+               if not IsValid(self.EntHolding) then
+                  hook.Remove("WeaponEquip", "TTT_WeaponOwnerFix"..self:EntIndex())
+                  return
+               end
+               if self.EntHolding == wep then
+                  self:Drop()
+               end
+            end)
+         end
       end
    end
 end


### PR DESCRIPTION
When a weapon is equipped while it's being held by a magneto stick, errors occur. The player is unable to shoot their weapon and the ammo count is potentially incorrect or not visible at all. The shotgun also spits errors when shot.

The magneto stick calls its Reset function after a weapon is equipped. Because there was no owner when the weapon was first picked up with the magneto stick, the owner is set to nil. Reequipping the weapon worked around this issue.

This fix uses the WeaponEquip hook which is called before the owner it set. This gives us time to call SWEP:Drop() and reset the owner before the new owner is set.