### PR TITLE
Font fixes and changes

### DIFF
--- a/garrysmod/lua/derma/init.lua
+++ b/garrysmod/lua/derma/init.lua
@@ -10,50 +10,44 @@
 -- The default font used by everything Derma
 --
 
---[[if ( system.IsOSX() ) then
+if ( system.IsLinux() ) then
 
-surface.CreateFont( "DermaDefault",
-{
-	font		= "Helvetica",
-	size		= 13,
-	antialias	= false,
-	weight		= 500
-})
+	surface.CreateFont( "DermaDefault",
+	{
+		font		= "DejaVu Sans",
+		size		= 14,
+		weight		= 500
+	})
 
-surface.CreateFont( "DermaDefaultBold",
-{
-	font		= "Helvetica",
-	size		= 13,
-	antialias	= false,
-	weight		= 800
-})
+	surface.CreateFont( "DermaDefaultBold",
+	{
+		font		= "DejaVu Sans",
+		size		= 14,
+		weight		= 800
+	})
 
+else
 
-else]]
+	surface.CreateFont( "DermaDefault",
+	{
+		font		= "Tahoma",
+		size		= 13,
+		weight		= 500
+	})
 
-surface.CreateFont( "DermaDefault",
-{
-	font		= "Tahoma",
-	size		= 13,
-	antialias	= true,
-	weight		= 500
-})
+	surface.CreateFont( "DermaDefaultBold",
+	{
+		font		= "Tahoma",
+		size		= 13,
+		weight		= 800
+	})
 
-surface.CreateFont( "DermaDefaultBold",
-{
-	font		= "Tahoma",
-	size		= 13,
-	antialias	= false,
-	weight		= 800
-})
-
---end
+end
 
 surface.CreateFont( "DermaLarge",
 {
 	font		= "Roboto",
 	size		= 32,
-	antialias	= true,
 	weight		= 500
 })
 

--- a/garrysmod/lua/menu/mount/vgui/workshop.lua
+++ b/garrysmod/lua/menu/mount/vgui/workshop.lua
@@ -1,9 +1,18 @@
 
 PANEL.Base = "DPanel"
 
+local wsFont
+if ( system.IsLinux() ) then
+	wsFont = "DejaVu Sans"
+elseif ( system.IsWindows() ) then
+	wsFont = "Tahoma"
+else
+	wsFont = "Helvetica"
+end
+
 surface.CreateFont( "WorkshopLarge",
 {
-	font		= "Helvetica",
+	font		= wsFont,
 	size		= 19,
 	antialias	= true,
 	weight		= 800
@@ -18,7 +27,7 @@ AccessorFunc( PANEL, "m_bDrawProgress", 			"DrawProgress", 			FORCE_BOOL )
 function PANEL:Init()
 
 	self.Label = self:Add( "DLabel" )
-	self.Label:SetText( "Updating Subscriptions.." )
+	self.Label:SetText( "Updating Subscriptions..." )
 	self.Label:SetFont( "WorkshopLarge" )
 	self.Label:SetTextColor( Color( 255, 255, 255, 200 ) )
 	self.Label:Dock( TOP )
@@ -32,7 +41,7 @@ function PANEL:Init()
 	self.ProgressLabel:SetTextColor( Color( 255, 255, 255, 50 ) )
 
 	self.TotalsLabel = self:Add( "DLabel" )
-	self.TotalsLabel:SetText( "File 1 or 30" )
+	self.TotalsLabel:SetText( "-" )
 	self.TotalsLabel:SetContentAlignment( 7 )
 	self.TotalsLabel:SetVisible( false )
 	self.TotalsLabel:SetTextColor( Color( 255, 255, 255, 50 ) )


### PR DESCRIPTION
* ~~Removed OS X specific Derma font. This now uses Tahoma like Windows.~~ Already done by @UnderscoreKilburn.
* Added Linux specific Derma font. Linux distros are more likely to have the close-looking DejaVu Sans than Tahoma. _This MAY fix the italic font some people had in Derma but will NOT fix surface.CreateFont using an italic font as a default if the font cannot be found. I was unable to reproduce this so I cannot confirm whether it even fixes Derma._
* Added Windows and Linux specific fonts to the Workshop download VGUI. Before this only had Helvetica which these systems may not have.