### PR TITLE
net.ReadType no longer requires an argument

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -108,7 +108,7 @@ function net.WriteTable( tab )
 	end
 	
 	-- End of table
-	net.WriteUInt( 0, 8 )
+	net.WriteType( nil )
 
 end
 
@@ -118,15 +118,10 @@ function net.ReadTable()
 	
 	while true do
 	
-		local t = net.ReadUInt( 8 )
-		if ( t == 0 ) then return tab end
-		local k = net.ReadType( t )
-	
-		local t = net.ReadUInt( 8 )
-		if ( t == 0 ) then return tab end
-		local v = net.ReadType( t )
+		local k = net.ReadType()
+		if ( k == nil ) then return tab end
 		
-		tab[ k ] = v
+		tab[ k ] = net.ReadType()
 		
 	end
 
@@ -176,6 +171,8 @@ net.ReadVars =
 }
 
 function net.ReadType( typeid )
+
+	typeid = typeid or net.ReadUInt( 8 )
 
 	local rv = net.ReadVars[ typeid ]
 	if ( rv ) then return rv() end


### PR DESCRIPTION
This makes it actually make sense to use, but also keeps backwards compatibility to help any poor soul who has used it anyway.

Also updates net.WriteTable and net.ReadTable to use it, which makes them a bit easier to understand.