### PR TITLE
Deprecation

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/base_entity/init.lua
+++ b/garrysmod/gamemodes/base/entities/entities/base_entity/init.lua
@@ -25,7 +25,7 @@ end
 --[[---------------------------------------------------------
    Name: OnRestore
    Desc: The game has just been reloaded. This is usually the right place
-		to call the GetNetworked* functions to restore the script's values.
+		to call the GetNW* functions to restore the script's values.
 -----------------------------------------------------------]]
 function ENT:OnRestore()
 end

--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/init.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/init.lua
@@ -1,6 +1,8 @@
 
 AddCSLuaFile( "cl_init.lua" )
 AddCSLuaFile( "shared.lua" )
+AddCSLuaFile( "ai_translations.lua" )
+AddCSLuaFile( "sh_anim.lua" )
 
 include( "shared.lua" )
 
@@ -12,7 +14,7 @@ SWEP.AutoSwitchFrom		= true		-- Auto switch from if you pick up a better weapon
 --[[---------------------------------------------------------
    Name: OnRestore
    Desc: The game has just been reloaded. This is usually the right place
-		to call the GetNetworked* functions to restore the script's values.
+		to call the GetNW* functions to restore the script's values.
 -----------------------------------------------------------]]
 function SWEP:OnRestore()
 end

--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/shared.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/shared.lua
@@ -1,6 +1,6 @@
 
-IncludeCS( "ai_translations.lua" )
-IncludeCS( "sh_anim.lua" )
+include( "ai_translations.lua" )
+include( "sh_anim.lua" )
 
 -- Variables that are used on both client and server
 

--- a/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
@@ -193,7 +193,7 @@ function GM:HUDDrawPickupHistory( )
 						
 			y = y + (v.height + 16)
 			tall = tall + v.height + 18
-			wide = math.Max( wide, v.width + v.height + 24 )
+			wide = math.max( wide, v.width + v.height + 24 )
 			
 			if (alpha == 0) then self.PickupHistory[k] = nil end
 		

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -38,12 +38,12 @@ function ENT:Think()
 end
 
 function ENT:SetOverlayText( text )
-	self:SetNetworkedString( "GModOverlayText", text )
+	self:SetNWString( "GModOverlayText", text )
 end
 
 function ENT:GetOverlayText()
 
-	local txt = self:GetNetworkedString( "GModOverlayText" )
+	local txt = self:GetNWString( "GModOverlayText" )
 	
 	if ( txt == "" ) then
 		return ""
@@ -67,7 +67,7 @@ function ENT:SetPlayer( ply )
 		self:SetVar( "Founder", ply )
 		self:SetVar( "FounderIndex", ply:UniqueID() )
 	
-		self:SetNetworkedString( "FounderName", ply:Nick() )
+		self:SetNWString( "FounderName", ply:Nick() )
 
 	end
 	
@@ -92,6 +92,6 @@ function ENT:GetPlayerName()
 		return ply:Nick()
 	end
 
-	return self:GetNetworkedString( "FounderName" )
+	return self:GetNWString( "FounderName" )
 	
 end

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_ghost.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_ghost.lua
@@ -22,8 +22,8 @@ end
 -----------------------------------------------------------]]
 function ENT:SetNetworkedBonePosition( i, Pos, Angle )
 
-	self:SetNetworkedVector( "Vector" .. i, Pos )
-	self:SetNetworkedAngle( "Angle" .. i, Angle )
+	self:SetNWVector( "Vector" .. i, Pos )
+	self:SetNWAngle( "Angle" .. i, Angle )
 
 end
 
@@ -38,7 +38,7 @@ function ENT:Draw()
 	local NumModelPhysBones = self:GetModelPhysBoneCount()
 	if (NumModelPhysBones > 1) then
 	
-		if ( !self:GetNetworkedVector( "Vector0", false ) ) then
+		if ( !self:GetNWVector( "Vector0", false ) ) then
 			return
 		end
 		

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_thruster.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_thruster.lua
@@ -14,27 +14,27 @@ if ( CLIENT ) then
 end
 
 function ENT:SetEffect( name )
-	self:SetNetworkedString( "Effect", name )
+	self:SetNWString( "Effect", name )
 end
 
 function ENT:GetEffect( name )
-	return self:GetNetworkedString( "Effect", "" )
+	return self:GetNWString( "Effect", "" )
 end
 
 function ENT:SetOn( boolon )
-	self:SetNetworkedBool( "On", boolon, true )
+	self:SetNWBool( "On", boolon, true )
 end
 
 function ENT:IsOn( name )
-	return self:GetNetworkedBool( "On", false )
+	return self:GetNWBool( "On", false )
 end
 
 function ENT:SetOffset( v )
-	self:SetNetworkedVector( "Offset", v, true )
+	self:SetNWVector( "Offset", v, true )
 end
 
 function ENT:GetOffset( name )
-	return self:GetNetworkedVector( "Offset" )
+	return self:GetNWVector( "Offset" )
 end
 
 function ENT:Initialize()

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
@@ -34,13 +34,13 @@ function TOOL:LeftClick( trace )
 		local eyeattachment = self.SelectedEntity:LookupAttachment( "eyes" )
 		if ( eyeattachment == 0 ) then return end
 		
-		self:GetWeapon():SetNetworkedEntity( 0, self.SelectedEntity )
+		self:GetWeapon():SetNWEntity( 0, self.SelectedEntity )
 
 	return true end
 
 	local selectedent = self.SelectedEntity
 	self.SelectedEntity = nil
-	self:GetWeapon():SetNetworkedEntity( 0, NULL )
+	self:GetWeapon():SetNWEntity( 0, NULL )
 	
 	if ( !IsValid( selectedent ) ) then return end
 	
@@ -58,7 +58,7 @@ end
 -----------------------------------------------------------]]
 function TOOL:RightClick( trace )
 
-	self:GetWeapon():SetNetworkedEntity( 0, NULL )
+	self:GetWeapon():SetNWEntity( 0, NULL )
 	self.SelectedEntity = nil
 	
 	if ( !IsValid( trace.Entity ) ) then return end
@@ -82,7 +82,7 @@ if ( CLIENT ) then
 	-----------------------------------------------------------]]
 	function TOOL:DrawHUD()
 	
-		local selected = self:GetWeapon():GetNetworkedEntity( 0 )
+		local selected = self:GetWeapon():GetNWEntity( 0 )
 		
 		if ( !IsValid( selected ) ) then return end
 		

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
@@ -23,11 +23,11 @@ local function IsUselessFaceFlex( strName )
 end
 
 function TOOL:FacePoserEntity()
-	return self:GetWeapon():GetNetworkedEntity( 1 )
+	return self:GetWeapon():GetNWEntity( 1 )
 end
 
 function TOOL:SetFacePoserEntity( ent )
-	return self:GetWeapon():SetNetworkedEntity( 1, ent )
+	return self:GetWeapon():SetNWEntity( 1, ent )
 end
 
 function TOOL:Think()

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
@@ -243,22 +243,22 @@ TranslateTable_VORT[ "ValveBiped.Bip01_R_Finger42" ] = "ValveBiped.pinky3_R"
 	Name: HandEntity
 -----------------------------------------------------------]]
 function TOOL:HandEntity()
-	return self:GetWeapon():GetNetworkedEntity( "HandEntity" )
+	return self:GetWeapon():GetNWEntity( "HandEntity" )
 end
 
 --[[---------------------------------------------------------
 	Name: HandNum
 -----------------------------------------------------------]]
 function TOOL:HandNum()
-	return self:GetWeapon():GetNetworkedInt( "HandNum" )
+	return self:GetWeapon():GetNWInt( "HandNum" )
 end
 
 --[[---------------------------------------------------------
 	Name: SetHand
 -----------------------------------------------------------]]
 function TOOL:SetHand( ent, iHand )
-	self:GetWeapon():SetNetworkedEntity( "HandEntity", ent )
-	self:GetWeapon():SetNetworkedInt( "HandNum", iHand )
+	self:GetWeapon():SetNWEntity( "HandEntity", ent )
+	self:GetWeapon():SetNWInt( "HandNum", iHand )
 end
 
 --[[------------------------------------------------------------

--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -23,7 +23,7 @@ end
 function meta:GetCount( str, minus )
 
 	if ( CLIENT ) then
-		return self:GetNetworkedInt( "Count."..str, 0 )
+		return self:GetNWInt( "Count."..str, 0 )
 	end
 	
 	minus = minus or 0
@@ -35,7 +35,7 @@ function meta:GetCount( str, minus )
 	
 	if ( !tab || !tab[ str ] ) then 
 	
-		self:SetNetworkedInt( "Count."..str, 0 )
+		self:SetNWInt( "Count."..str, 0 )
 		return 0 
 		
 	end
@@ -52,7 +52,7 @@ function meta:GetCount( str, minus )
 	
 	end
 	
-	self:SetNetworkedInt( "Count."..str, c - minus )
+	self:SetNWInt( "Count."..str, c - minus )
 
 	return c
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
@@ -201,7 +201,7 @@ function SWEP:PrimaryAttack()
    end
 
    if ( (game.SinglePlayer() && SERVER) || CLIENT ) then
-      self:SetNetworkedFloat( "LastShootTime", CurTime() )
+      self:SetNWFloat( "LastShootTime", CurTime() )
    end
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hudpickup.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hudpickup.lua
@@ -185,7 +185,7 @@ function GM:HUDDrawPickupHistory()
 
          y = y + (v.height + 16)
          tall = tall + v.height + 18
-         wide = math.Max( wide, v.width + v.height + 24 )
+         wide = math.max( wide, v.width + v.height + 24 )
 
          if alpha == 0 then self.PickupHistory[k] = nil end
       end

--- a/garrysmod/lua/includes/deprecation.lua
+++ b/garrysmod/lua/includes/deprecation.lua
@@ -1,0 +1,74 @@
+local function DEPRECATE( f, name, alternative )
+
+	local error_locations = {}
+	local format = "[ERROR] %s:%d: calling deprecated function '%s'\n"
+
+	if ( alternative ) then
+		format = "[ERROR] %s:%d: calling deprecated function '%s' (use '%s')\n"
+	end
+
+	return function( ... )
+
+		local info = debug.getinfo( 2, "Sl" )
+
+		if info then
+
+			local source, currentline = info.short_src, info.currentline
+
+			if ( not error_locations[source .. currentline] ) then
+
+				error_locations[source .. currentline] = true
+				ErrorNoHalt( string.format( format, source, currentline, name, alternative ) )
+
+			end
+
+		end
+
+		return f( ... )
+
+	end
+
+end
+
+
+local ENTITY = FindMetaTable( "Entity" )
+local PLAYER = FindMetaTable( "Player" )
+
+IncludeCS 									= DEPRECATE( IncludeCS, "IncludeCS", "include & AddCSLuaFile" )
+
+math.Dist 									= DEPRECATE( math.Dist, "math.Dist", "math.Distance" )
+math.Max 									= DEPRECATE( math.Max, "math.Max", "math.max" )
+math.Min 									= DEPRECATE( math.Min, "math.Min", "math.min" )
+math.mod 									= DEPRECATE( math.mod, "math.mod", "math.fmod" )
+
+util.tobool 								= DEPRECATE( util.tobool, "util.tobool", "tobool" )
+util.TraceEntityHull 						= DEPRECATE( util.TraceEntityHull, "util.TraceEntityHull" )
+
+ENTITY.GetNetworkedAngle 					= DEPRECATE( ENTITY.GetNetworkedAngle, "ENTITY:GetNetworkedAngle", "ENTITY:GetNWAngle" )
+ENTITY.GetNetworkedBool 					= DEPRECATE( ENTITY.GetNetworkedBool, "ENTITY:GetNetworkedBool", "ENTITY:GetNWBool" )
+ENTITY.GetNetworkedEntity 					= DEPRECATE( ENTITY.GetNetworkedEntity, "ENTITY:GetNetworkedEntity", "ENTITY:GetNWEntity" )
+ENTITY.GetNetworkedFloat 					= DEPRECATE( ENTITY.GetNetworkedFloat, "ENTITY:GetNetworkedFloat", "ENTITY:GetNWFloat" )
+ENTITY.GetNetworkedInt 						= DEPRECATE( ENTITY.GetNetworkedInt, "ENTITY:GetNetworkedInt", "ENTITY:GetNWInt" )
+ENTITY.GetNetworkedString 					= DEPRECATE( ENTITY.GetNetworkedString, "ENTITY:GetNetworkedString", "ENTITY:GetNWString" )
+ENTITY.GetNetworkedVector 					= DEPRECATE( ENTITY.GetNetworkedVector, "ENTITY:GetNetworkedVector", "ENTITY:GetNWVector" )
+
+ENTITY.SetNetworkedAngle 					= DEPRECATE( ENTITY.SetNetworkedAngle, "ENTITY:SetNetworkedAngle", "ENTITY:SetNWAngle" )
+ENTITY.SetNetworkedBool 					= DEPRECATE( ENTITY.SetNetworkedBool, "ENTITY:SetNetworkedBool", "ENTITY:SetNWBool" )
+ENTITY.SetNetworkedEntity 					= DEPRECATE( ENTITY.SetNetworkedEntity, "ENTITY:SetNetworkedEntity", "ENTITY:SetNWEntity" )
+ENTITY.SetNetworkedFloat 					= DEPRECATE( ENTITY.SetNetworkedFloat, "ENTITY:SetNetworkedFloat", "ENTITY:SetNWFloat" )
+ENTITY.SetNetworkedInt 						= DEPRECATE( ENTITY.SetNetworkedInt, "ENTITY:SetNetworkedInt", "ENTITY:SetNWInt" )
+ENTITY.SetNetworkedString 					= DEPRECATE( ENTITY.SetNetworkedString, "ENTITY:SetNetworkedString", "ENTITY:SetNWString" )
+ENTITY.SetNetworkedVector 					= DEPRECATE( ENTITY.SetNetworkedVector, "ENTITY:SetNetworkedVector", "ENTITY:SetNWVector" )
+
+PLAYER.GetPunchAngle 						= DEPRECATE( PLAYER.GetPunchAngle, "PLAYER:GetPunchAngle", "PLAYER:GetViewPunchAngles" )
+
+if SERVER then
+
+	ENTITY.GetHitboxBone 					= DEPRECATE( ENTITY.GetHitboxBone, "ENTITY:GetHitboxBone", "ENTITY:GetHitBoxBone" )
+
+else
+
+	SScale 									= DEPRECATE( SScale, "SScale", "ScreenScale" )
+	ValidPanel 								= DEPRECATE( ValidPanel, "ValidPanel", "IsValid" )
+
+end

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -68,7 +68,7 @@ end
 -----------------------------------------------------------]]
 function meta:IsConstrained()
 
-	if (CLIENT) then return self:GetNetworkedBool( "IsConstrained" ) end
+	if (CLIENT) then return self:GetNWBool( "IsConstrained" ) end
 	
 	local c = self:GetTable().Constraints
 	local bIsConstrained = false
@@ -82,7 +82,7 @@ function meta:IsConstrained()
 		
 	end
 
-	self:SetNetworkedBool( "IsConstrained", bIsConstrained )
+	self:SetNWBool( "IsConstrained", bIsConstrained )
 	return bIsConstrained
 	
 end

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -1,15 +1,15 @@
 
 --[[---------------------------------------------------------
-   Name: Dist( low, high )
+   Name: Distance( low, high )
    Desc: Distance between two 2d points
 ------------------------------------------------------------]]
-function math.Dist( x1, y1, x2, y2 )
+function math.Distance( x1, y1, x2, y2 )
 	local xd = x2-x1
 	local yd = y2-y1
 	return math.sqrt( xd*xd + yd*yd )
 end
 
-math.Distance = math.Dist -- alias
+math.Dist = math.Distance -- alias
 
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/player_auth.lua
+++ b/garrysmod/lua/includes/extensions/player_auth.lua
@@ -28,7 +28,7 @@ end
 function meta:IsUserGroup(name)
     if not self:IsValid() then return false end
 
-    return self:GetNetworkedString("UserGroup") == name
+    return self:GetNWString("UserGroup") == name
 end
 
 --[[---------------------------------------------------------
@@ -36,7 +36,7 @@ end
     Desc: Returns the player's usergroup.
 -----------------------------------------------------------]]
 function meta:GetUserGroup()
-    return self:GetNetworkedString("UserGroup", "user")
+    return self:GetNWString("UserGroup", "user")
 end
 
 
@@ -51,7 +51,7 @@ if not SERVER then return end
     Desc: Sets the player's usergroup. ( Serverside Only )
 -----------------------------------------------------------]]
 function meta:SetUserGroup(name)
-    self:SetNetworkedString("UserGroup", name)
+    self:SetNWString("UserGroup", name)
 end
 
 

--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -122,3 +122,4 @@ if ( CLIENT ) then
 
 end
 
+include ( "deprecation.lua" )

--- a/garrysmod/lua/send.txt
+++ b/garrysmod/lua/send.txt
@@ -168,6 +168,7 @@ lua\includes\extensions\client\panel\animation.lua
 lua\includes\extensions\client\panel\dragdrop.lua
 lua\includes\extensions\client\panel\scriptedpanels.lua
 lua\includes\extensions\client\panel\selections.lua
+lua\includes\deprecation.lua
 lua\derma\init.lua
 lua\derma\derma.lua
 lua\derma\derma_example.lua

--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -96,10 +96,10 @@ function PANEL:DrawModel()
 	while(curparent:GetParent() != nil) do
 		curparent = curparent:GetParent()
 		local x,y = previous:GetPos()
-		topy = math.Max(y, topy+y)
-		leftx = math.Max(x, leftx+x)
-		bottomy = math.Min(y+previous:GetTall(), bottomy + y)
-		rightx = math.Min(x+previous:GetWide(), rightx + x)
+		topy = math.max(y, topy+y)
+		leftx = math.max(x, leftx+x)
+		bottomy = math.min(y+previous:GetTall(), bottomy + y)
+		rightx = math.min(x+previous:GetWide(), rightx + x)
 		previous = curparent
 	end
 	render.SetScissorRect(leftx,topy,rightx, bottomy, true)

--- a/garrysmod/lua/vgui/dnumberscratch.lua
+++ b/garrysmod/lua/vgui/dnumberscratch.lua
@@ -167,7 +167,7 @@ function PANEL:DrawNotches( level, x, y, w, h, range, value, min, max )
 	local halfw = w * 0.5
 	local span = math.ceil( w / size )
 	local realmid = x + w * 0.5 - (value * self:GetZoom());
-	local mid = x + w * 0.5 - math.mod( value * self:GetZoom(), size );
+	local mid = x + w * 0.5 - math.fmod( value * self:GetZoom(), size );
 	local top = h * 0.4;
 	local nh = h - (top);
 

--- a/garrysmod/lua/vgui/fingervar.lua
+++ b/garrysmod/lua/vgui/fingervar.lua
@@ -170,10 +170,10 @@ function PANEL:Paint( w, h )
 	local wep = LocalPlayer():GetWeapon( "gmod_tool" )
 	if ( !IsValid( wep ) ) then return end
 
-	local ent = wep:GetNetworkedEntity( "HandEntity" )
+	local ent = wep:GetNWEntity( "HandEntity" )
 	if ( !IsValid( ent ) || !ent.FingerIndex ) then return end
 
-	local boneid = ent.FingerIndex[ tonumber( self.VarName:sub( 8 ) ) + 1 + 15 * wep:GetNetworkedEntity( "HandNum", 0 ) ]
+	local boneid = ent.FingerIndex[ tonumber( self.VarName:sub( 8 ) ) + 1 + 15 * wep:GetNWEntity( "HandNum", 0 ) ]
 	if ( !boneid || ent:GetBoneName( boneid ) == "__INVALIDBONE__" ) then return end
 
 	local v = self:GetValue()

--- a/garrysmod/lua/vgui/prop_boolean.lua
+++ b/garrysmod/lua/vgui/prop_boolean.lua
@@ -27,7 +27,7 @@ function PANEL:Setup( vars )
 
 	-- Set the value
 	self.SetValue = function( self, val )
-		ctrl:SetChecked( util.tobool( val ) ) 
+		ctrl:SetChecked( tobool( val ) ) 
 	end
 
 	-- Alert row that value changed


### PR DESCRIPTION
__Not being merged until after next update, if at all.__

I'd like to consider this a step in the right direction for cleaning up a lot of inconsistencies in Garry's Mod's function / method naming. Calls to deprecated functions will cause a non-aborting error message once per location.

There are still a few things to be done to the DEPRECATE function itself.
If you have any suggestions for this / functions that should be deprecated, post them. If you have any arguments against this / functions this deprecates, post them.

Most of the deprecated functions are from http://wiki.garrysmod.com/page/Category:Deprecated_Functions
Two exceptions for this are math.Min and math.Max, which aren't on the wiki at all.

```
> print(math.Distance(1, 2, 3, 4))
	2.8284271247462
	
> print(math.Dist(1, 2, 3, 4))
	[ERROR] lua_run:1: calling deprecated function 'math.Dist' (use 'math.Distance')
	2.8284271247462
```

I consider this a good idea because, if functions are to be removed in the future, why not convince developers to stop using them in the present?

View the beef at https://github.com/wiox/garrysmod/blob/deprecate/garrysmod/lua/includes/deprecation.lua

__Opinions very much needed__