### PR TITLE
DColumnSheet Button Colors

### DIFF
--- a/garrysmod/lua/vgui/dcolumnsheet.lua
+++ b/garrysmod/lua/vgui/dcolumnsheet.lua
@@ -67,7 +67,7 @@ function PANEL:AddSheet( label, panel, material )
 	
 	if ( self.ButtonOnly ) then
 		Sheet.Button:SizeToContents()
-		Sheet.Button:SetColor( Color( 150, 150, 150, 100 ) )
+		-- Sheet.Button:SetColor( Color( 150, 150, 150, 100 ) )
 	end
 	
 	table.insert( self.Items, Sheet )
@@ -88,13 +88,13 @@ function PANEL:SetActiveButton( active )
 	if ( self.ActiveButton && self.ActiveButton.Target ) then	
 		self.ActiveButton.Target:SetVisible( false )
 		self.ActiveButton:SetSelected( false )
-		self.ActiveButton:SetColor( Color( 150, 150, 150, 100 ) )
+		-- self.ActiveButton:SetColor( Color( 150, 150, 150, 100 ) )
 	end
 
 	self.ActiveButton = active
 	active.Target:SetVisible( true )
 	active:SetSelected( true )
-	active:SetColor( Color( 255, 255, 255, 255 ) )
+	-- active:SetColor( Color( 255, 255, 255, 255 ) )
 	
 	self.Content:InvalidateLayout()
 


### PR DESCRIPTION
Buttons no longer refuse to change their color back. This was an issue because they were never set back to their original color.
Instead, it uses SetSelected on the buttons when they are selected or deselected--like it was already doing--which is the only thing that is necessary to actually do.

CHANGED: Removed superfluous color changes for buttons on selection in DColumnSheet.