### PR TITLE
Fixed TTT crowbar's decals and sounds

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -142,8 +142,8 @@ function SWEP:PrimaryAttack()
          edata:SetStart(spos)
          edata:SetOrigin(tr_main.HitPos)
          edata:SetNormal(tr_main.Normal)
-
-         --edata:SetSurfaceProp(tr_main.MatType)
+         edata:SetSurfaceProp(tr_main.SurfaceProps)
+         edata:SetHitBox(tr_main.HitBox)
          --edata:SetDamageType(DMG_CLUB)
          edata:SetEntity(hitEnt)
 


### PR DESCRIPTION
Since TTT's crowbar doesn't apply decals onto models and doesn't use correct sounds & decals based on $surfaceprop, I've added two extra parameters to the EffectData - SetSurfaceProp(tr_main.SurfaceProps) and SetHitBox(tr_main.HitBox).
For example, hitting a metal model now applies a corresponding Impact decal to the model and emits the correct sound.