### PR TITLE
Regression: Fixed missing arrow in player count dropdown menu

### DIFF
--- a/garrysmod/html/js/svc.Tranny.js
+++ b/garrysmod/html/js/svc.Tranny.js
@@ -10,23 +10,44 @@ angular.module( 'tranny', [] )
 		var update = function()
 		{
 			if ( IN_ENGINE == false ) return;
-			
-			$(element).html( language.Update( strName ) );
-			$(element).attr( "placeholder", language.Update( strName ) );
-		}
-		
-		scope.$watch( attrs.ngTranny, function ( value ) 
+
+			var langText = language.Update( strName );
+
+			var children = $( element ).contents().filter( function() { return this.nodeType == 3; } )
+			var replaced = false;
+			children.each( function()
+			{
+				if ( $( this ).text().trim().length !== 0 )
+				{
+					if ( replaced )
+					{
+						$( this ).remove();
+						return true; // Skip to next iteration
+					}
+					$( this ).replaceWith( langText );
+					replaced = true;
+				}
+			} );
+			if ( children.length === 0 )
+			{
+				$( element ).html( langText );
+			}
+
+			$( element ).attr( "placeholder", langText );
+		};
+
+		scope.$watch( attrs.ngTranny, function ( value )
 		{
 			strName = value;
 			update();
-		});
+		} );
 
 		scope.$on( 'languagechanged', function()
 		{
 			update();
-		})
+		} );
 
-	}
+	};
 } )
 
 .directive( 'ngSeconds', function ( $parse )
@@ -45,11 +66,10 @@ angular.module( 'tranny', [] )
 
 			if ( value < 60 * 60 * 24 )
 				return $( element ).html( Math.floor( value / 60 / 60 ) + " hr" );
-			
+
 			$( element ).html( "a long time" );
 
-		});
+		} );
 
-	}
+	};
 } );
-


### PR DESCRIPTION
The Tranny module previously replaced the whole inner HTML of an element when translating text. This would replace any child HTML node instead of just text ones. This wasn't an issue in the main menu until 9d71f76 when we started dealing with child HTML nodes.

https://github.com/garrynewman/garrysmod/blob/72fe957ed00b3d7fd6296ca30bf6c19edb9a8c77/garrysmod/html/template/newgame.html#L40-L43

The module now checks for child text nodes, replaces one and removes the rest while leaving all other child nodes intact. If no child nodes were found in the first place, the inner HTML is simply replaced like before.