### PR TITLE
DFrame's description typo fix

### DIFF
--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -267,4 +267,4 @@ function PANEL:PerformLayout()
 
 end
 
-derma.DefineControl( "DFrame", "A simpe window", PANEL, "EditablePanel" )
+derma.DefineControl( "DFrame", "A simple window", PANEL, "EditablePanel" )


### PR DESCRIPTION
It said "A simpe window"

Now it says "A simple window"

For the love of all that is the English language, I **demand** this change to be made.