### PR TITLE
Added string.CharSub for string substitution with numbers

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -298,6 +298,15 @@ function string.GetChar( s, k )
 
 end
 
+function string.CharSub( str, k, strReplace )
+	
+	local len = string.len( strReplace )
+	local start = str:sub( 0, k - 1 )
+	local send = str:sub( k + len )
+	
+	return start .. strReplace .. send	
+end
+
 local meta = getmetatable( "" )
 
 function meta:__index( key )


### PR DESCRIPTION
CharSub is basically a more powerful string.Char; instead of replacing 1 character at the index, you force multiple characters in at the index. It could be equivalent to using multiple string.Char functions with increasing indexes (x + 1, x + 2, x+ 3) or exploding the string by "", replacing the keys ( 1, 2, 3 ), and concatenating the table together with "". It is very useful when you want a function like gsub but with a numeric key instead of a substring.

Example:
local myString = "Hello World"
myString  = string.CharSub( myString, 3, "foo" )
print( myString )
-- "Hefoo World"

I've found this to be particularly useful when adding ellipses to strings manually and prefer doing this over string.Explode and table.concat.