### PR TITLE
Made OnUndo get called by hook.Call

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -318,25 +318,45 @@ end
 function GM:HUDPaint()
    local client = LocalPlayer()
 
-   hook.Call( "HUDDrawTargetID", GAMEMODE )
-
-   MSTACK:Draw(client)
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTTargetID" ) then
+       hook.Call( "HUDDrawTargetID", GAMEMODE )
+   end
+   
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTMStack" ) then
+       MSTACK:Draw(client)
+   end
 
    if (not client:Alive()) or client:Team() == TEAM_SPEC then
-      SpecHUDPaint(client)
+      if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTSpecHUD" ) then
+          SpecHUDPaint(client)
+      end
 
       return
    end
 
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTRadar" ) then
+       RADAR:Draw(client)
+   end
+   
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTHUD" ) then
+       TBHUD:Draw(client)
+   end
+   
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTWSwitch" ) then
+       WSWITCH:Draw(client)
+   end
 
-   RADAR:Draw(client)
-   TBHUD:Draw(client)
-   WSWITCH:Draw(client)
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTVoice" ) then
+       VOICE.Draw(client)
+   end
+   
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTDisguise" ) then
+       DISGUISE.Draw(client)
+   end
 
-   VOICE.Draw(client)
-   DISGUISE.Draw(client)
-
-   hook.Call( "HUDDrawPickupHistory", GAMEMODE )
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTPickupHistory" ) then
+       hook.Call( "HUDDrawPickupHistory", GAMEMODE )
+   end
 
    -- Draw bottom left info panel
    InfoPaint(client)

--- a/garrysmod/lua/includes/modules/undo.lua
+++ b/garrysmod/lua/includes/modules/undo.lua
@@ -370,9 +370,9 @@ function Do_Undo( undo )
 	
 	if (count > 0) then
 		if ( undo.CustomUndoText ) then
-			undo.Owner:SendLua( "GAMEMODE:OnUndo( '"..undo.Name.."', '"..undo.CustomUndoText.."' )" )
+			undo.Owner:SendLua( "hook.Call( 'OnUndo', GAMEMODE, '"..undo.Name.."', '"..undo.CustomUndoText.."' )" )
 		else
-			undo.Owner:SendLua( "GAMEMODE:OnUndo( '"..undo.Name.."' )" )
+			undo.Owner:SendLua( "hook.Call( 'OnUndo', GAMEMODE, '"..undo.Name.."' )" )
 		end
 	end
 	


### PR DESCRIPTION
Previously, if a player undid something in a gamemode that wasn't sandbox or derived from sandbox, there would be an error on the client, using hook.Call however prevents that.