### PR TITLE
Adds util.IsIndexable and improves table.SortByMember.

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -356,41 +356,56 @@ function table.ForceInsert( t, v )
 end
 
 --[[---------------------------------------------------------
-	Name: table.SortByMember( table )
-	Desc: Sorts table by named member
+   Name: table.SortByMember( table )
+   Desc: Sorts table by named member. All values being sorted must have the same datatype.
 -----------------------------------------------------------]]
 function table.SortByMember( Table, MemberName, bAsc )
 
-	local TableMemberSort = function( a, b, MemberName, bReverse ) 
-
+	local function TableMemberSort( a, b )
+	
 		--
-		-- All this error checking kind of sucks, but really is needed
+		-- Swap the tables if we are sorting in ascending order
 		--
-		if ( !istable( a ) ) then return !bReverse end
-		if ( !istable( b ) ) then return bReverse end
-		if ( !a[ MemberName ] ) then return !bReverse end
-		if ( !b[ MemberName ] ) then return bReverse end
+		if bAsc then
 
-		if ( type( a[ MemberName ] ) == "string" ) then
-
-			if ( bReverse ) then
-				return a[ MemberName ]:lower() < b[ MemberName ]:lower()
-			else
-				return a[ MemberName ]:lower() > b[ MemberName ]:lower()
-			end
+			a, b = b, a
 
 		end
 
-		if ( bReverse ) then
-			return a[ MemberName ] < b[ MemberName ]
-		else
-			return a[ MemberName ] > b[ MemberName ]
+		--
+		-- Enforce both values as indexable with the targetted member
+		--
+		if ( !util.IsIndexable( a ) or !a[MemberName] ) then return false end
+		if ( !util.IsIndexable( b ) or !b[MemberName] ) then return true end
+
+		local aVal, bVal = a[MemberName], b[MemberName]
+
+		--
+		-- If the member is a method, call them and sort using the method's result
+		--
+		if ( isfunction( aVal ) ) then
+
+			aVal, bVal = aVal( a ), bVal( b )
+
 		end
 
+		--
+		-- Force strings to be lowercase
+		--
+		if ( isstring( aVal ) ) then
+
+			aVal, bVal = aVal:lower(), bVal:lower()
+
+		end	
+
+		return aVal > bVal
+		
 	end
 
-	table.sort( Table, function( a, b ) return TableMemberSort( a, b, MemberName, bAsc or false ) end )
+	table.sort( Table, TableMemberSort )
 
+	return Table
+	
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -347,3 +347,19 @@ function util.RemovePData( steamid, name )
 	sql.Query( "DELETE FROM playerpdata WHERE infoid = "..SQLStr(name) )
 	
 end
+
+--[[---------------------------------------------------------
+   Name: IsIndexable( val )
+   Desc: Returns true if the given value can be indexed
+-----------------------------------------------------------]]
+function util.IsIndexable( val )
+
+	local meta = debug.getmetatable( val )
+
+	if istable( val ) or ( istable( meta ) and ( istable( meta.__index ) or isfunction( meta.__index ) ) ) then
+		return true
+	end
+
+	return false
+
+end


### PR DESCRIPTION
util.IsIndexable returns true if a value can be indexed. i.e. Lua will actually attempt to index it either as a table or via metamethods.

table.SortByMember can now sort non-table yet indexable values (such as players) as well as sort by methods. It also returns the table it has sorted for those wacky one-liners.

```lua
-- Prints a list of players in ascending order by name
for k, v in pairs( table.SortByMember( player.GetAll(), "Name", true ) ) do

	print( v )

end

-- Prints a list of players in order of most score
for k, v in pairs( table.SortByMember( player.GetAll(), "Frags" ) ) do

	print( v, v:Frags() )

end
```

Crap like that. Any code that manages to use this already without error will continue to work 100% the same.