### PR TITLE
Fix DPropertySheet padding on bottom edge.

### DIFF
--- a/garrysmod/lua/vgui/dpropertysheet.lua
+++ b/garrysmod/lua/vgui/dpropertysheet.lua
@@ -332,7 +332,8 @@ function PANEL:PerformLayout()
 	end
 	
 	if ( !ActivePanel.NoStretchY ) then 
-		ActivePanel:SetTall( (self:GetTall() - ActiveTab:GetTall() ) - Padding ) 
+		local _, y = ActivePanel:GetPos()
+		ActivePanel:SetTall( self:GetTall() - y - Padding )
 	else
 		ActivePanel:CenterVertical()
 	end


### PR DESCRIPTION
Previously the bottom padding on the panel in a DPropertySheet was always exactly 8px, because the active tab is 8px taller than the other tabs[¹](https://github.com/AbigailBuccaneer/garrysmod/blob/patch-1/garrysmod/lua/vgui/dpropertysheet.lua#L117). However, the default padding is 8px, so this is only revealed when changing the padding on a property sheet.

(A previous version of this PR is at #859, but I managed to break GitHub and it's now un-reopenable.)