### PR TITLE
Properties can only be used on weapons when unheld

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/shared.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/shared.lua
@@ -235,6 +235,13 @@ function GM:CanProperty( pl, property, ent )
 
 	end
 
+	--
+	-- Weapons can only be property'd if nobody is holding them
+	--
+	if ( ent:IsWeapon() and IsValid( ent:GetOwner() ) ) then
+		return false
+	end
+
 	-- Give the entity a chance to decide
 	if ( ent.CanProperty ) then
 		return ent:CanProperty( pl, property )


### PR DESCRIPTION
This stops people joining innocent prop-protection-less sandbox servers and
removing everybody's weapons.
Instead they can only instantly remove every prop on the map! Oh well.

The only alternative is saving right-click state server-side and that's quite gross. 
Install prop-protection, kids.