### PR TITLE
GM hook calls

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -81,7 +81,7 @@ end
 
 function meta:LimitHit( str )
 
-	self:SendLua( "GAMEMODE:LimitHit( '".. str .."' )" )
+	self:SendLua( 'hook.Run("LimitHit","' .. str .. '")' )
 
 end
 
@@ -110,7 +110,7 @@ if (SERVER) then
 		self.Hints = self.Hints or {}
 		if (self.Hints[ str ]) then return end
 		
-		self:SendLua( "GAMEMODE:AddHint( '"..str.."', "..delay.." )" )
+		self:SendLua( 'hook.Run("AddHint","' .. str .. '","' .. delay .. '")' )
 		self.Hints[ str ] = true
 
 	end
@@ -120,7 +120,7 @@ if (SERVER) then
 		self.Hints = self.Hints or {}
 		if (self.Hints[ str ]) then return end
 		
-		self:SendLua( "GAMEMODE:SuppressHint( '"..str.."' )" )
+		self:SendLua( 'hook.Run("SuppressHint","' .. str .. '")' )
 		self.Hints[ str ] = true
 
 	end

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -122,7 +122,7 @@ if ( SERVER ) then
 			
 			-- Send tooltip command to client
 			if ( count > 0 ) then
-				pl:SendLua( "GAMEMODE:OnCleanup( 'all' )" )
+				pl:SendLua( 'hook.Run("OnCleanup","all")' )
 			end
 			
 			return
@@ -141,7 +141,7 @@ if ( SERVER ) then
 		table.Empty( cleanup_list[id][args[1]] )
 		
 		-- Send tooltip command to client
-		pl:SendLua( "GAMEMODE:OnCleanup( '"..args[1].."' )" )
+		pl:SendLua( 'hook.Run("OnCleanup","' .. args[1] .. '")' )
 		
 	end
 	
@@ -170,7 +170,7 @@ if ( SERVER ) then
 			game.CleanUpMap()
 			
 			-- Send tooltip command to client
-			if ( IsValid( pl ) ) then pl:SendLua( "GAMEMODE:OnCleanup( 'all' )" ) end
+			if ( IsValid( pl ) ) then pl:SendLua( 'hook.Run("OnCleanup","all")' ) end
 			
 			return
 			
@@ -195,7 +195,7 @@ if ( SERVER ) then
 		end
 		
 		-- Send tooltip command to client
-		if ( IsValid( pl ) ) then pl:SendLua( "GAMEMODE:OnCleanup( '"..args[1].."' )" ) end
+		if ( IsValid( pl ) ) then pl:SendLua( 'hook.Run("OnCleanup","' .. args[1] .. '")' ) end
 		
 	end
 	

--- a/garrysmod/lua/includes/modules/undo.lua
+++ b/garrysmod/lua/includes/modules/undo.lua
@@ -370,9 +370,9 @@ function Do_Undo( undo )
 	
 	if (count > 0) then
 		if ( undo.CustomUndoText ) then
-			undo.Owner:SendLua( "GAMEMODE:OnUndo( '"..undo.Name.."', '"..undo.CustomUndoText.."' )" )
+			undo.Owner:SendLua( 'hook.Run("OnUndo","' .. undo.Name .. '","' .. undo.CustomUndoText .. '")' )
 		else
-			undo.Owner:SendLua( "GAMEMODE:OnUndo( '"..undo.Name.."' )" )
+			undo.Owner:SendLua( 'hook.Run("OnUndo","' .. undo.Name .. '")' )
 		end
 	end
 	


### PR DESCRIPTION
Cleans up gamemode hook calls using SendLua. Prevents errors in non-sandbox gamemodes.
* All GM method calls via SendLua now use hook.Run