### PR TITLE
Add lua_findhooks

### DIFF
--- a/garrysmod/lua/autorun/developer_functions.lua
+++ b/garrysmod/lua/autorun/developer_functions.lua
@@ -10,7 +10,7 @@ local function FindInTable( tab, find, parents, depth )
 	
 	for k, v in pairs ( tab ) do
 	
-		if ( type(k) == "string" ) then
+		if ( isstring(k) ) then
 		
 			if ( k && k:lower():find( find:lower() ) ) then
 
@@ -27,7 +27,7 @@ local function FindInTable( tab, find, parents, depth )
 				k != "_LOADED" &&
 				k != "__index" ) then
 				
-				local NewParents = parents .. k .. ".";
+				local NewParents = parents .. k .. "."
 				FindInTable( v, find, NewParents, depth )
 			
 			end
@@ -38,31 +38,69 @@ local function FindInTable( tab, find, parents, depth )
 
 end
 
+local function FindInHooks( base, name )
+
+	for b, t in pairs( hook.GetTable() ) do
+
+		local head = true
+
+		if ( istable( t ) && b:lower():find( base:lower() ) ) then
+
+			for n, f in pairs( t ) do
+
+				if ( !name || tostring( n ):lower():find( tostring( name ):lower() ) ) then
+
+					if ( head ) then Msg( "\n\t", b, " hooks:\n" ) head = false end
+
+					Msg( "\t\t", tostring( n ), " - (", tostring( f ), ")\n" )
+
+				end
+
+			end
+
+		end
+
+	end
+
+end
+
 
 --[[---------------------------------------------------------
    Name:	Find
 -----------------------------------------------------------]]   
 local function Find( ply, command, arguments )
 
-	if ( IsValid(ply) && ply:IsPlayer() && !ply:IsAdmin() ) then return end
+	if ( !game.SinglePlayer() && IsValid(ply) && ply:IsPlayer() && !ply:IsAdmin() ) then return end
 	if ( !arguments[1] ) then return end
 	
-	if ( SERVER ) then 	Msg("Finding '", arguments[1], "' SERVERSIDE:\n\n") else
-						Msg("Finding '", arguments[1], "' CLIENTSIDE:\n\n") end
-	
-	FindInTable( _G, arguments[1] )
-	FindInTable( debug.getregistry(), arguments[1] )
-	
+	if ( command:StartWith( "lua_findhooks" ) ) then
+
+		Msg( "Finding '", arguments[1], "' hooks ",
+			( arguments[2] && "with name '" .. arguments[2] .. "' " || "" ),
+			( SERVER && "SERVERSIDE" || "CLIENTSIDE" ), ":\n\n"
+		)
+		FindInHooks( arguments[1], arguments[2] )
+
+	else
+
+		Msg( "Finding '", arguments[1], "' ", ( SERVER && "SERVERSIDE" || "CLIENTSIDE" ), ":\n\n" )
+		FindInTable( _G, arguments[1] )
+		FindInTable( debug.getregistry(), arguments[1] )
+
+	end
+
 	Msg("\n\n")
 	
 	if ( SERVER && IsValid(ply) && ply:IsPlayer() && ply:IsListenServerHost() ) then
-		RunConsoleCommand( "lua_find_cl", tostring(arguments[1]) );
+		RunConsoleCommand( command .. "_cl", arguments[1], arguments[2] )
 	end
 	
 end
 
 if ( SERVER ) then
-	concommand.Add( "lua_find", Find, nil, "", { FCVAR_DONTRECORD } )
+	concommand.Add( "lua_find", Find, _, "", { FCVAR_DONTRECORD } )
+	concommand.Add( "lua_findhooks", Find, _, "", { FCVAR_DONTRECORD } )
 else
-	concommand.Add( "lua_find_cl", Find, nil, "", { FCVAR_DONTRECORD } )
+	concommand.Add( "lua_find_cl", Find, _, "", { FCVAR_DONTRECORD } )
+	concommand.Add( "lua_findhooks_cl", Find, _, "", { FCVAR_DONTRECORD } )
 end


### PR DESCRIPTION
Adds new ccmds **lua_findhooks** and **lua_findhooks_cl** to behave similarly to *lua_find*.
* Allows quick searching of all registered hooks by hook name & identifier
* Integrated into current ccmd callback
* Usage is: *lua_findhooks(_cl) \<hookname> \<hookid>*

Additional changes:
* Changes use of type() to isstring()
* Dev funcs now work in SP regardless of usergroup NWString

**Examples**
``` lua_findhooks render frame ``` - Finds all hooks with *render* in the hook name and *frame* in the identifier.
``` lua_findhooks_cl "" player ``` - Finds all clientside hooks of any name with *player* in the identifier.
``` lua_findhooks think ``` - Finds all think hooks.