### PR TITLE
Improve error message when indexing string badly (with key not within the string library)

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -307,7 +307,7 @@ function meta:__index( key )
 	elseif ( tonumber( key ) ) then
 		return self:sub( key, key )
 	else
-		error( "bad key to string index (number expected, got " .. type( key ) .. ")", 2 )
+		error( "attempt to index a string value with bad key ('" .. tostring( key ) .. "' is not part of the string library)", 2 )
 	end
 end
 


### PR DESCRIPTION
The current error message is very difficult for new (and old) developers to understand and also doesn't resemble any error messages in stock Lua.

```lua
local str = "Hello!"; print( str:sab( 1, 5 ) )

--[[
    New Error: [ERROR] lua_run:1: attempt to index a string value with bad key ('sab' is not part of the string library)
    Old Error: [ERROR] lua_run:1: bad key to string index (number expected, got string)
]]
```

I'd almost be in favour of following the way stock Lua handles this and returning nil, but it'd a better idea to stick to current functionality of gmod.