### PR TITLE
Allow spectators to talk in all chat -- redirects to team

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -82,11 +82,6 @@ function GM:PlayerBindPress(ply, bind, pressed)
             GAMEMODE.ForcedMouse = true
          end
       end
-   elseif bind == "messagemode" and pressed and ply:IsSpec() then
-      if GAMEMODE.round_state == ROUND_ACTIVE and DetectiveMode() then
-         LANG.Msg("spec_teamchat_hint")
-         return true
-      end
    elseif bind == "noclip" and pressed then
       if not GetConVar("sv_cheats"):GetBool() then
          RunConsoleCommand("ttt_equipswitch")

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -120,10 +120,10 @@ function GM:PlayerSay(ply, text, team_only)
 
          table.insert( filtered, 1, "[MUMBLED]")
          return table.concat(filtered, " ")
-	  else
-         ply:ConCommand("say_team " .. text )
+      else
+         ply:Say(text, true)
 	     return ""
-	  end
+      end
    end
 
    if team_only and ply:Team() != TEAM_SPEC and GetRoundState() == ROUND_ACTIVE then
@@ -131,7 +131,7 @@ function GM:PlayerSay(ply, text, team_only)
          -- traitor chat handling
          RoleChatMsg(ply, ply:GetRole(), text)
       else
-         ply:ConCommand("say " .. text )
+         ply:Say(text)
       end
 
       return ""


### PR DESCRIPTION
Also, allows innos to use team chat. Both redirect to team chat and all chat respectively, but it's beneficial in situations such as a person getting killed while typing and they lose their message after they send it; or someone trying to quickly type who the killer is before they are killed, but they hit the wrong key.

This still supports the mumbling and spec all chat systems