### PR TITLE
Remove the need for DEFINE_BASECLASS in player classes

### DIFF
--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -313,7 +313,7 @@ function RegisterClass( name, table, base )
 
 		if ( !Type[ name ] ) then ErrorNoHalt( "RegisterClass - deriving "..name.." from unknown class "..base.."!\n" ) end
 		setmetatable( Type[ name ], { __index = Type[ base ] } )
-
+      table.BaseClass = baseclass.Get(base);
 	end
 
 	if ( SERVER ) then


### PR DESCRIPTION
Very small and simple change that removes the need for DEFINE_BASECLASS in player classes. I find it convenient however this change is a tad costly. It is fully backwards compatible, but if developers remove the DEFINE_BASECLASS from their class files, they will have to replace BaseClass with self.BaseClass.