### PR TITLE
Made prop_generic not error without a setup table

### DIFF
--- a/garrysmod/lua/vgui/prop_generic.lua
+++ b/garrysmod/lua/vgui/prop_generic.lua
@@ -43,7 +43,7 @@ function PANEL:Setup( vars )
 	self:Clear()
 
 	local text = self:Add( "DTextEntry" )
-	if ( !vars.waitforenter ) then text:SetUpdateOnType( true ) end
+	if (vars && !vars.waitforenter ) then text:SetUpdateOnType( true ) end
 	text:SetDrawBackground( false )
 	text:Dock( FILL )
 


### PR DESCRIPTION
This was confusing, there's nothing in the wiki documenting a setup table.