### PR TITLE
net.ReadType no longer has typeid arg

### DIFF
--- a/garrysmod/lua/includes/modules/net.lua
+++ b/garrysmod/lua/includes/modules/net.lua
@@ -175,7 +175,9 @@ net.ReadVars =
 	[TYPE_COLOR]	= function ()	return net.ReadColor() end,
 }
 
-function net.ReadType( typeid )
+function net.ReadType()
+	 
+	local typeid = net.ReadUInt(8)
 
 	local rv = net.ReadVars[ typeid ]
 	if ( rv ) then return rv() end


### PR DESCRIPTION
net.WriteType writes the typeid as a UInt at the same time as writing the object

Didn't really make sense to have net.ReadType require you to manually net.ReadUInt()