### PR TITLE
Allow for custom TTT Scoreboard ScoreGroups

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -49,12 +49,18 @@ GROUP_SPEC = 4
 
 GROUP_COUNT = 4
 
+function AddScoreGroup(name) -- Utility function to register a score group
+   if _G["GROUP_"..name] then error("Group of name '"..name.."' already exists!") return end
+   GROUP_COUNT = GROUP_COUNT + 1
+   _G["GROUP_"..name] = GROUP_COUNT
+end
+
 function ScoreGroup(p)
    if not IsValid(p) then return -1 end -- will not match any group panel
 
    local group = hook.Call( "TTTScoreGroup", nil, p )
 
-   if group then
+   if group then -- If that hook gave us a group, use it
       return group
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -52,6 +52,12 @@ GROUP_COUNT = 4
 function ScoreGroup(p)
    if not IsValid(p) then return -1 end -- will not match any group panel
 
+   local group = hook.Call( "TTTScoreGroup", nil, p )
+
+   if group then
+      return group
+   end
+
    if DetectiveMode() then
       if p:IsSpec() and (not p:Alive()) then
          if p:GetNWBool("body_found", false) then
@@ -117,6 +123,8 @@ function PANEL:Init()
       t:SetGroupInfo(GetTranslation("sb_confirmed"), Color(130, 170, 10, 100), GROUP_FOUND)
       self.ply_groups[GROUP_FOUND] = t
    end
+
+   hook.Call( "TTTScoreGroups", nil, self.ply_frame:GetCanvas(), self.ply_groups )
 
    -- the various score column headers
    self.cols = {}


### PR DESCRIPTION
The purpose of this commit is to allow developers to create new player groups on the TTT Scoreboard. Previously, people had to implement [hacky](https://github.com/Tommy228/TTT_Spectator_Deathmatch/blob/master/lua/cl_spectator_deathmatch.lua#L126-L190) [overrides](https://github.com/Tommy228/TTT_Spectator_Deathmatch/blob/master/lua/cl_spectator_deathmatch.lua#L276-L307). (Two links)
If anyone has a better method of implementing this, please comment. Specifically, I'm not sure about that Initialize hook just to modify the GROUP_COUNT variable/grab ourselves an index.
Details:
Adds two hooks:
- TTTScoreGroup(ply)
- TTTScoreGroups(pnl, groupstbl)
And one function:
- AddScoreGroup(name)

Returning a number in TTTScoreGroup will set the given player's scoregroup to that number (index in the groupstbl)

The TTTScoreGroups hook is where all of the setup happens:
1. You must first register a ScoreGroup with AddScoreGroup(name). A global variable of GROUP_..name is set and GROUP_COUNT is incremented automatically.
2. Then, you create a new "TTTScoreGroup" panel and parent it to the panel passed as the first argument of the hook.
3. Next you must call SetGroupInfo(name, color, index) on your TTTScoreGroup panel.
4. Lastly, add an entry to the second argument (table of groups) with the key of your GROUP_ with the value of your panel.

This example is working and explains all of the features.
Example usage:
```lua
if not CLIENT then return end

-- fluff
local META_PLAYER = FindMetaTable("Player")
function META_PLAYER:IsInDeathmatch()
	return (self.Deathmatch)
end
hook.Add("OnPlayerChat", "TTTDeathmatch_PlayerChat", function(ply, text, isTeam, isDead)
	if text == "!deathmatch" then
		ply.Deathmatch = not ply.Deathmatch
		chat.AddText("You "..(ply.Deathmatch and "entered" or "left").." TTTDeathmatch!")
		return true
	end
end)
-- end fluff

hook.Add("TTTScoreGroups", "TTTDeathmatch_AddScoreGroup", function(pnl, groupstbl)
	AddScoreGroup("TTTDM")
	local group = vgui.Create("TTTScoreGroup", pnl)
	group:SetGroupInfo("Deathmatch", Color(100, 200, 200), GROUP_TTTDM)
	groupstbl[GROUP_TTTDM] = group
end)

hook.Add("TTTScoreGroup", "TTTDeathmatch_SetScoreGroup", function(ply)
	return (ply:IsInDeathmatch() and GROUP_TTTDM) or nil
end)
```