### PR TITLE
Panels now default to having an empty Init method

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -192,6 +192,7 @@ function vgui.Register( name, mtable, base )
 
 	-- Default base is Panel
 	mtable.Base = base or "Panel"	
+	mtable.Init = mtable.Init or function() end
 	
 	PanelFactory[ name ] = mtable
 	baseclass.Set( name, mtable )
@@ -216,6 +217,7 @@ function vgui.RegisterTable( mtable, base )
 	PANEL = nil
 
 	mtable.Base = base or "Panel"
+	mtable.Init = mtable.Init or function() end
 	
 	return mtable
 	
@@ -234,6 +236,7 @@ function vgui.RegisterFile( filename )
 	PANEL = OldPanel
 
 	mtable.Base = mtable.Base or "Panel"
+	mtable.Init = mtable.Init or function() end
 	
 	return mtable
 	


### PR DESCRIPTION
This fixes the issue with constructor chaining causing a panel class' Init method to call multiple times. This screenshot may trigger some harsh memories:
![](http://i.imgur.com/8dRvI4z.png)

This is caused by the following code - in which the DFrame's Init method is called twice. This causes extra child elements to be created.
```lua
vgui.Register( "MyPanel", {}, "DFrame" )
vgui.Create( "MyPanel" ) : SetSize( 400, 300 )
```

Another example can be seen from the following code, where the Base class's Init method calls print twice rather than once.
```lua
--
-- Base
--
local Base = {}

function Base:Init()
	print "Base:Init"
end

vgui.Register( "MyBase", Base, "Panel" )

--
-- Panel
--
vgui.Register( "MyPanel", {}, "MyBase" )


vgui.Create( "MyPanel" )
```

> Base:Init
> Base:Init