### PR TITLE
[DGrid] Use table.remove instead of setting to nil

### DIFF
--- a/garrysmod/lua/vgui/dgrid.lua
+++ b/garrysmod/lua/vgui/dgrid.lua
@@ -65,7 +65,7 @@ function PANEL:RemoveItem( item, bDontDelete )
 	
 		if ( panel == item ) then
 		
-			self.Items[ k ] = nil
+			table.remove(self.Items, k)
 			
 			if (!bDontDelete) then
 				panel:Remove()


### PR DESCRIPTION
This fixes SortByMember not working after item removal, because there are gaps in the Items table.