### PR TITLE
Remove developer __tostring method as functionality integration in game and game-modes in favor of new ToString function.

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/edit_sun.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/edit_sun.lua
@@ -68,7 +68,7 @@ end
 function ENT:OnAngleChange( newang )
 
 	if ( IsValid( self.EnvSun ) ) then
-		self.EnvSun:SetKeyValue( "sun_dir", tostring( newang:Forward() ) );
+		self.EnvSun:SetKeyValue( "sun_dir", newang:Forward():ToString() );
 	end
 
 end

--- a/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
@@ -198,8 +198,8 @@ list.Set( "DesktopWindows", "PlayerEditor", {
 
 		local function UpdateFromControls()
 
-			RunConsoleCommand( "cl_playercolor", tostring( plycol:GetVector() ) )
-			RunConsoleCommand( "cl_weaponcolor", tostring( wepcol:GetVector() ) )
+			RunConsoleCommand( "cl_playercolor", plycol:GetVector():ToString() )
+			RunConsoleCommand( "cl_weaponcolor", wepcol:GetVector():ToString() )
 
 		end
 

--- a/garrysmod/lua/includes/extensions/angle.lua
+++ b/garrysmod/lua/includes/extensions/angle.lua
@@ -23,6 +23,6 @@ end
 -----------------------------------------------------------]]
 function meta:ToString( )
 
-	return tostring( self.p ) .. " " .. ( self.y ) .. " " .. tostring( self.r )
+	return string.format( "%d %d %d", self.x, self.y, self.z )
 
 end

--- a/garrysmod/lua/includes/extensions/angle.lua
+++ b/garrysmod/lua/includes/extensions/angle.lua
@@ -16,3 +16,13 @@ function meta:SnapTo( component, degrees )
 	return self
 
 end
+
+--[[---------------------------------------------------------
+	Angle ToString returns "p y r" so that __tostring
+	can be altered without breaking game-modes!
+-----------------------------------------------------------]]
+function meta:ToString( )
+
+	return tostring( self.p ) .. " " .. ( self.y ) .. " " .. tostring( self.r )
+
+end

--- a/garrysmod/lua/includes/extensions/vector.lua
+++ b/garrysmod/lua/includes/extensions/vector.lua
@@ -17,6 +17,6 @@ end
 -----------------------------------------------------------]]
 function meta:ToString( )
 
-	return tostring( self.x ) .. " " .. ( self.y ) .. " " .. tostring( self.z )
+	return string.format( "%d %d %d", self.p, self.y, self.r )
 
 end

--- a/garrysmod/lua/includes/extensions/vector.lua
+++ b/garrysmod/lua/includes/extensions/vector.lua
@@ -10,3 +10,13 @@ function meta:ToColor( )
 	return Color( self.x * 255, self.y * 255, self.z * 255 )
 
 end
+
+--[[---------------------------------------------------------
+	Vector ToString returns "x y z" so that __tostring
+	can be altered without breaking game-modes!
+-----------------------------------------------------------]]
+function meta:ToString( )
+
+	return tostring( self.x ) .. " " .. ( self.y ) .. " " .. tostring( self.z )
+
+end

--- a/garrysmod/lua/includes/gmsave/physics.lua
+++ b/garrysmod/lua/includes/gmsave/physics.lua
@@ -13,8 +13,8 @@ function gmsave.PhysicsSave( ent )
 		local obj = ent:GetPhysicsObjectNum( k )
 		
 		tab[ k ] = {}
-		tab[ k ].origin = tostring( obj:GetPos() )
-		tab[ k ].angles = tostring( obj:GetAngles() )
+		tab[ k ].origin = obj:GetPos():ToString()
+		tab[ k ].angles = obj:GetAngles():ToString()
 		tab[ k ].mass = tostring( obj:GetMass() )
 		tab[ k ].material = tostring( obj:GetMaterial() )
 		if ( !obj:IsMotionEnabled() ) then tab[ k ].frozen = 1; end

--- a/garrysmod/lua/includes/modules/ai_task.lua
+++ b/garrysmod/lua/includes/modules/ai_task.lua
@@ -3,7 +3,6 @@
 if ( CLIENT ) then return end
 
 local setmetatable 	= setmetatable
-local tostring 		= tostring
 local table			= table
 local Msg			= Msg
 local Error			= Error

--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -340,30 +340,31 @@ function CreateKeyframeRope( Pos, width, material, Constraint, Ent1, LPos1, Bone
 
 	-- Attachment point 1
 	rope:SetEntity( "StartEntity", Ent1 )
-	rope:SetKeyValue( "StartOffset", tostring( LPos1 ) )
+	rope:SetKeyValue( "StartOffset", LPos1:ToString() )
 	rope:SetKeyValue( "StartBone", Bone1 )
-	
+
 	-- Attachment point 2
 	rope:SetEntity( "EndEntity", Ent2 )
-	rope:SetKeyValue( "EndOffset", tostring( LPos2 ) )
+	rope:SetKeyValue( "EndOffset", LPos2:ToString() )
 	rope:SetKeyValue( "EndBone", Bone2 )
-	
+
 	if ( kv ) then
 		for k, v in pairs( kv ) do
-		
-			rope:SetKeyValue( k, tostring( v ) )
-	
+
+			local value = ( isangle( v ) || isvector( v ) || ( istable( v ) && v.ToString ) ) && v:ToString() || tostring( v )
+			rope:SetKeyValue( k, value )
+
 		end
 	end
-	
+
 	rope:Spawn()
 	rope:Activate()
-	
+
 	-- Delete the rope if the attachments get killed
 	Ent1:DeleteOnRemove( rope )
 	Ent2:DeleteOnRemove( rope )
 	if ( Constraint && Constraint:IsValid() ) then Constraint:DeleteOnRemove( rope ) end
-	
+
 	return rope
 
 end
@@ -501,7 +502,7 @@ function Rope( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, length, addlength, forcel
 			-- Create the constraint
 			Constraint = ents.Create("phys_lengthconstraint")
 				Constraint:SetPos( WPos1 )
-				Constraint:SetKeyValue( "attachpoint", tostring(WPos2) )
+				Constraint:SetKeyValue( "attachpoint", WPos2:ToString() )
 				Constraint:SetKeyValue( "minlength", "0.0" )
 				Constraint:SetKeyValue( "length", length + addlength )
 				if ( forcelimit ) then Constraint:SetKeyValue( "forcelimit", forcelimit ) end
@@ -576,7 +577,7 @@ function Elastic( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, constant, damping, rda
 		
 			Constraint = ents.Create( "phys_spring" )
 			Constraint:SetPos( WPos1 )
-			Constraint:SetKeyValue( "springaxis", tostring( WPos2 ) )
+			Constraint:SetKeyValue( "springaxis", WPos2:ToString() )
 			Constraint:SetKeyValue( "constant", constant )
 			Constraint:SetKeyValue( "damping", damping )
 			Constraint:SetKeyValue( "relativedamping", rdamping )
@@ -736,7 +737,7 @@ function Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
 
 		local Constraint = ents.Create("phys_slideconstraint")
 		Constraint:SetPos( WPos1 )
-		Constraint:SetKeyValue( "slideaxis", tostring( WPos2 ) )
+		Constraint:SetKeyValue( "slideaxis", WPos2:ToString() )
 		Constraint:SetPhysConstraintObjects( Phys1, Phys2 )
 		Constraint:Spawn()
 		Constraint:Activate()
@@ -797,7 +798,7 @@ function Axis( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, forcelimit, torquelimit, 
 
 		local Constraint = ents.Create("phys_hinge")
 		Constraint:SetPos( WPos1 )
-		Constraint:SetKeyValue( "hingeaxis", tostring( WPos2 ) )
+		Constraint:SetKeyValue( "hingeaxis", WPos2:ToString() )
 		if ( forcelimit && forcelimit > 0 ) then Constraint:SetKeyValue( "forcelimit", forcelimit ) end
 		if ( torquelimit && torquelimit > 0 ) then Constraint:SetKeyValue( "torquelimit", torquelimit ) end
 		if ( friction && friction > 0 ) then Constraint:SetKeyValue( "hingefriction", friction ) end
@@ -1060,7 +1061,7 @@ function Motor( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, friction, torque, forcet
 	
 		local Constraint = ents.Create("phys_torque")
 		Constraint:SetPos( WPos1 )
-		Constraint:SetKeyValue( "axis", tostring( WPos2 ) )
+		Constraint:SetKeyValue( "axis", WPos2:ToString() )
 		Constraint:SetKeyValue( "force", torque )
 		Constraint:SetKeyValue( "forcetime", forcetime )
 		Constraint:SetKeyValue( "spawnflags", 4 )
@@ -1144,9 +1145,9 @@ function Pulley( Ent1, Ent4, Bone1, Bone4, LPos1, LPos4, WPos2, WPos3, forcelimi
 
 		local Constraint = ents.Create( "phys_pulleyconstraint" )
 		Constraint:SetPos( WPos2 )
-		Constraint:SetKeyValue( "position2", tostring( WPos3 ) )
-		Constraint:SetKeyValue( "ObjOffset1", tostring( LPos1 ) )
-		Constraint:SetKeyValue( "ObjOffset2", tostring( LPos4 ) )
+		Constraint:SetKeyValue( "position2", WPos3:ToString() )
+		Constraint:SetKeyValue( "ObjOffset1", LPos1:ToString() )
+		Constraint:SetKeyValue( "ObjOffset2", LPos4:ToString() )
 		Constraint:SetKeyValue( "forcelimit", forcelimit )
 		Constraint:SetKeyValue( "addlength", ( WPos3 - WPos4 ):Length() )
 		if ( rigid ) then Constraint:SetKeyValue( "spawnflags", 2 ) end

--- a/garrysmod/lua/includes/modules/numpad.lua
+++ b/garrysmod/lua/includes/modules/numpad.lua
@@ -18,7 +18,6 @@ local concommand 	= concommand
 local PrintTable 	= PrintTable
 local ErrorNoHalt 	= ErrorNoHalt
 local saverestore	= saverestore
-local tostring		= tostring
 local math			= math
 local IsValid		= IsValid
 

--- a/garrysmod/lua/includes/modules/saverestore.lua
+++ b/garrysmod/lua/includes/modules/saverestore.lua
@@ -1,6 +1,5 @@
 
 local Msg			= Msg
-local tostring 		= tostring
 local type			= type
 local pairs			= pairs
 local string		= string

--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -36,13 +36,24 @@ function IsColor( obj )
 end
 
 
+
+--[[---------------------------------------------------------
+	Returns color as a string ( unlinks necessity of
+	using tostring for functionality )
+-----------------------------------------------------------]]
+function COLOR:ToString()
+	
+	return string.format( "%d %d %d %d", self.r, self.g, self.b, self.a )
+	
+end
+
 --[[---------------------------------------------------------
 	Returns color as a string
 -----------------------------------------------------------]]
 function COLOR:__tostring()
-	
-	return string.format( "%d %d %d %d", self.r, self.g, self.b, self.a )
-	
+
+	return self:ToString( )
+
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/vgui/dcolormixer.lua
+++ b/garrysmod/lua/vgui/dcolormixer.lua
@@ -307,7 +307,7 @@ function PANEL:UpdateConVar( strName, strKey, color )
 	if ( !strName ) then return end
 	local col = color[strKey]
 
-	RunConsoleCommand( strName, tostring( col ) )
+	RunConsoleCommand( strName, col:ToString() )
 
 	self[ 'ConVarOld'..strName ] = col
 end

--- a/garrysmod/lua/vgui/dcolorpalette.lua
+++ b/garrysmod/lua/vgui/dcolorpalette.lua
@@ -176,7 +176,7 @@ function PANEL:UpdateConVar( strName, strKey, color )
 
 	if ( !strName ) then return end
 
-	RunConsoleCommand( strName, tostring( color[ strKey ] ) )
+	RunConsoleCommand( strName, color[ strKey ]:ToString() )
 
 end
 

--- a/garrysmod/lua/vgui/prop_vectorcolor.lua
+++ b/garrysmod/lua/vgui/prop_vectorcolor.lua
@@ -64,7 +64,7 @@ function PANEL:Setup( vars )
 			-- convert color to vector
 			local vec = Vector( newcol.r / 255, newcol.g / 255, newcol.b / 255 )
 
-			self:ValueChanged( tostring( vec ), true )
+			self:ValueChanged( vec:ToString(), true )
 
 		end
 


### PR DESCRIPTION
This pull request removes __tostring integration for functionality throughout the game ( where tostring( color ), tostring( vector ), or tostring( angle ) is used, they're changed to color:ToString( ), angle:ToString( ), vector:ToString( ) ) so that data-types with identical __tostring output ( such as angle and vector ) can be altered to something legible such as Vector( x, y, z ) and Angle( p, y, r ) with the arguments replaced with %d in string.format by developers without breaking gamemodes such as sandbox and DarkRP or the game which uses __tostring to explode "x y r" or "p y r" as arguments, or whatever...

This effectively allows devs to control __tostring without the game relying on that output ( because __tostring is a developer function to read the data, not for serialization )

I also removed a few empty line tabs / spaces in one or more files.
I also removed, in a few files, tostring localization which was never used in said files