### PR TITLE
TTT: Replaced use of COLLISION_GROUP_DEBRIS_TRIGGER

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -358,6 +358,8 @@ local function GetSceneData(victim, attacker, dmginfo)
 end
 
 local rag_collide = CreateConVar("ttt_ragdoll_collide", "0")
+-- 0 = Don't collide with players and props
+-- 1 = Don't collide with players
 
 -- Creates client or server ragdoll depending on settings
 function CORPSE.Create(ply, attacker, dmginfo)
@@ -375,7 +377,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
    rag:Activate()
 
    -- nonsolid to players, but can be picked up and shot
-   rag:SetCollisionGroup(rag_collide:GetBool() and COLLISION_GROUP_WEAPON or COLLISION_GROUP_DEBRIS_TRIGGER)
+   rag:SetCollisionGroup(rag_collide:GetBool() and COLLISION_GROUP_WEAPON or COLLISION_GROUP_WORLD)
 
    -- flag this ragdoll as being a player's
    rag.player_ragdoll = true


### PR DESCRIPTION
http://facepunch.com/showthread.php?p=47498190

Tested this on a dev server running this script: https://github.com/Kefta/Ragdoll-Remover
Simulated high ragdoll velocity and overlapping collision groups. Without the change, the script triggered 7/10 times. With the change, it triggered 1/10 times (from a C4 blast, which sends it at a high velocity anyway).