### PR TITLE
Fix rare stack overflow with table.Merge

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -73,14 +73,16 @@ end
    Name: xx
    Desc: xx
 -----------------------------------------------------------]]
-function table.Merge(dest, source)
+function table.Merge(dest, source, lookup_table)
+	lookup_table = lookup_table or {}
+	lookup_table[dest] = true
 
 	for k,v in pairs(source) do
 	
-		if ( type(v) == 'table' && type(dest[k]) == 'table' ) then
+		if ( type(v) == 'table' && type(dest[k]) == 'table' && !lookup_table[dest[k]] ) then
 			-- don't overwrite one table with another
 			-- instead merge them recurisvely
-			table.Merge(dest[k], v)
+			table.Merge(dest[k], v, lookup_table)
 		else
 			dest[k] = v
 		end


### PR DESCRIPTION
This happens when you merge similar tables that contain themselves (e.g.
Lua refresh, which does something like table.Merge(oldgm, newgm)).

```lua
  local t1 = { name = "Tom" }; t1.self = t1;
  local t2 = { name = "Joe" }; t2.self = t2;
  table.Merge(t1, t2) -- stack overflow
```
or if you're being lazy with metatables,
```lua
  GM.Foo = {}
  GM.Foo.__index = GM.Foo
  -- every Lua refresh afterward causes a stack overflow
```

It's not a very common use case, but we had to patch it on our server and I figured I'd try to get it fixed here.