### PR TITLE
Expand OnLuaError to all realms

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -6,7 +6,8 @@
 include ( "util.lua" )			-- Misc Utilities
 include ( "util/sql.lua" )		-- Include sql here so it's
 								-- available at loadtime to modules.
-							
+include ( "util/errors.lua" )		-- Errors
+			
 include( "extensions/net.lua" )
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/util/errors.lua
+++ b/garrysmod/lua/includes/util/errors.lua
@@ -1,0 +1,9 @@
+local oldError = debug.getregistry()[1]
+
+-- Override the error function to call our hook
+debug.getregistry()[1] = function( strError )
+
+	oldError( strError )
+	hook.Run( "OnLuaError", strError, (CLIENT and 1 or 0) )
+	
+end


### PR DESCRIPTION
This takes the OnLuaError hook, which currently is only available in the menu realm, and allows it to be called in the client/server realms as well. Its been requested before (https://github.com/Facepunch/garrysmod-requests/issues/149) but for the most part ignored since I figure a good solution would require modifying it in Garry's mod's source. So this is a solution that I've heard from Meep and MDave on seperate occasions. Obviously this hook doesn't return anything like stopping the actual error function from being called because that is prone to abuse. Lastly this differs from the menu calling of the hook because it omits the last 2 arguments but actually uses the second argument (1 for Client 0 for Server). 

This would allow developers to track whenever a Lua error occurs, without wrapping everything in PCalls, and run functions for that. I planned on using something like this in my gPhone so I could dump a log of all the gPhone events to a text file whenever a Lua error occured to help replicate bugs but never got around to it. I don't think the uses are limited to that. 

Example:

    hook.Add("OnLuaError", "errortest", function( error, realm, name, id )
        if realm == 1 then
            print("Client", error)
        else
            print("Server", error)
        end
    end)

>Client	addons/exho scrap/lua/scraparmor/cl_inventory.lua:23: attempt to index global 'frame' (a nil value)

>[ERROR] addons/exho scrap/lua/scraparmor/cl_inventory.lua:23: attempt to index global 'frame' (a nil >value)
>  1. __index - addons/exho scrap/lua/autorun/scrap_adder.lua:30
>   2. unknown - addons/exho scrap/lua/scraparmor/cl_inventory.lua:23
>    3. unknown - lua/includes/modules/concommand.lua:54

