### PR TITLE
Added Pre and PostDraw functions for DModelPanel

### DIFF
--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -89,6 +89,10 @@ end
 	Name: DrawModel
 -----------------------------------------------------------]]
 function PANEL:DrawModel()
+	if hook.Run("PreDrawModelPanel", self, self.Entity) == false then 
+		return 
+	end
+	
 	local curparent = self
 	local rightx = self:GetWide()
 	local leftx = 0
@@ -107,6 +111,8 @@ function PANEL:DrawModel()
 	render.SetScissorRect( leftx, topy, rightx, bottomy, true )
 	self.Entity:DrawModel()
 	render.SetScissorRect( 0, 0, 0, 0, false )
+	
+	hook.Run("PostDrawModelPanel", self, self.Entity)
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -89,7 +89,7 @@ end
 	Name: DrawModel
 -----------------------------------------------------------]]
 function PANEL:DrawModel()
-	if hook.Run("PreDrawModelPanel", self, self.Entity) == false then 
+	if self:PreDrawModel( self.Entity ) == false then 
 		return 
 	end
 	
@@ -112,7 +112,21 @@ function PANEL:DrawModel()
 	self.Entity:DrawModel()
 	render.SetScissorRect( 0, 0, 0, 0, false )
 	
-	hook.Run("PostDrawModelPanel", self, self.Entity)
+	self:PostDrawModel( self.Entity )
+end
+
+--[[---------------------------------------------------------
+	Name: PreDrawModel
+-----------------------------------------------------------]]
+function PANEL:PreDrawModel( ent )
+	return true
+end
+
+--[[---------------------------------------------------------
+	Name: PostDrawModel
+-----------------------------------------------------------]]
+function PANEL:PostDrawModel( ent )
+	
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -89,9 +89,6 @@ end
 	Name: DrawModel
 -----------------------------------------------------------]]
 function PANEL:DrawModel()
-	if self:PreDrawModel( self.Entity ) == false then 
-		return 
-	end
 	
 	local curparent = self
 	local rightx = self:GetWide()
@@ -109,10 +106,17 @@ function PANEL:DrawModel()
 		previous = curparent
 	end
 	render.SetScissorRect( leftx, topy, rightx, bottomy, true )
+
+	if self:PreDrawModel( self.Entity ) == false then 
+		return 
+	end
+
 	self.Entity:DrawModel()
-	render.SetScissorRect( 0, 0, 0, 0, false )
-	
+
 	self:PostDrawModel( self.Entity )
+
+	render.SetScissorRect( 0, 0, 0, 0, false )
+
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Used just like Pre/PostPlayerDraw except for the DModelPanel entity. Return false on the Pre function to stop the rendering of the model and then you can modify the entity after its drawn in the Post function without having to override the DrawModel function. This can be used to set the material of the entity or take a pointshop-esque approach and render clientside models around the entity

I use this to draw clientside models onto a DModelPanel with pretty much the same code I have in PostPlayerDraw to draw the models onto the player.
https://github.com/Exho1/ScrapCombat/blob/master/lua/scraparmor/cl_inventory.lua#L130