### PR TITLE
Added DMenu radio buttons and DMenuOption disable support

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -493,7 +493,7 @@ end
 -----------------------------------------------------------]]
 function SKIN:PaintMenuOption( panel, w, h )
 
-	if ( panel.m_bBackground && (panel.Hovered || panel.Highlight) && !panel:GetDisabled() ) then
+	if ( panel.m_bBackground && (panel.Hovered || panel.Highlight) ) then
 		self.tex.MenuBG_Hover( 0, 0, w, h )
 	end
 	

--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -104,10 +104,10 @@ SKIN.tex.Checkbox_Checked			= GWEN.CreateTextureNormal( 448, 32, 15, 15 )
 SKIN.tex.Checkbox					= GWEN.CreateTextureNormal( 464, 32, 15, 15 )
 SKIN.tex.CheckboxD_Checked			= GWEN.CreateTextureNormal( 448, 48, 15, 15 )
 SKIN.tex.CheckboxD					= GWEN.CreateTextureNormal( 464, 48, 15, 15 )
---SKIN.tex.RadioButton_Checked		= GWEN.CreateTextureNormal( 448, 64, 15, 15 )
---SKIN.tex.RadioButton				= GWEN.CreateTextureNormal( 464, 64, 15, 15 )
---SKIN.tex.RadioButtonD_Checked		= GWEN.CreateTextureNormal( 448, 80, 15, 15 )
---SKIN.tex.RadioButtonD				= GWEN.CreateTextureNormal( 464, 80, 15, 15 )
+SKIN.tex.RadioButton_Checked		= GWEN.CreateTextureNormal( 448, 64, 15, 15 )
+SKIN.tex.RadioButton				= GWEN.CreateTextureNormal( 464, 64, 15, 15 )
+SKIN.tex.RadioButtonD_Checked		= GWEN.CreateTextureNormal( 448, 80, 15, 15 )
+SKIN.tex.RadioButtonD				= GWEN.CreateTextureNormal( 464, 80, 15, 15 )
 SKIN.tex.TreePlus					= GWEN.CreateTextureNormal( 448, 96, 15, 15 )
 SKIN.tex.TreeMinus					= GWEN.CreateTextureNormal( 464, 96, 15, 15 )
 --SKIN.tex.Menu_Strip				= GWEN.CreateTextureBorder( 0, 128, 127, 21, 1, 1, 1, 1 )
@@ -493,12 +493,36 @@ end
 -----------------------------------------------------------]]
 function SKIN:PaintMenuOption( panel, w, h )
 
-	if ( panel.m_bBackground && (panel.Hovered || panel.Highlight) ) then
+	if ( panel.m_bBackground && (panel.Hovered || panel.Highlight) && !panel:GetDisabled() ) then
 		self.tex.MenuBG_Hover( 0, 0, w, h )
 	end
 	
 	if ( panel:GetChecked() ) then
-		self.tex.Menu_Check( 5, h/2-7, 15, 15 )
+		
+		if ( panel:GetRadioGroup() ) then
+			
+			if ( panel:GetDisabled() ) then
+				self.tex.RadioButtonD_Checked( 5, h/2-7, 15, 15 )
+			else
+				self.tex.RadioButton_Checked( 5, h/2-7, 15, 15 )
+			end
+			
+		else
+			self.tex.Menu_Check( 5, h/2-7, 15, 15 )
+		end
+		
+	else
+		
+		if ( panel:GetRadioGroup() ) then
+			
+			if ( panel:GetDisabled() ) then
+				self.tex.RadioButtonD( 5, h/2-7, 15, 15 )
+			else
+				self.tex.RadioButton( 5, h/2-7, 15, 15 )
+			end
+			
+		end
+		
 	end
 
 end
@@ -979,6 +1003,5 @@ function SKIN:PaintMenuBar( panel, w, h )
 	self.tex.Menu_Strip( 0, 0, w, h )
 
 end
-
 
 derma.DefineSkin( "Default", "Made to look like regular VGUI", SKIN )

--- a/garrysmod/lua/vgui/dmenu.lua
+++ b/garrysmod/lua/vgui/dmenu.lua
@@ -1,14 +1,3 @@
---[[   _                                
-    ( )                               
-   _| |   __   _ __   ___ ___     _ _ 
- /'_` | /'__`\( '__)/' _ ` _ `\ /'_` )
-( (_| |(  ___/| |   | ( ) ( ) |( (_| |
-`\__,_)`\____)(_)   (_) (_) (_)`\__,_) 
-
-	DMenu
-
---]]
-
 local PANEL = {}
 
 AccessorFunc( PANEL, "m_bBorder", 			"DrawBorder" )
@@ -20,9 +9,6 @@ AccessorFunc( PANEL, "m_iMaxHeight", 		"MaxHeight" )
 AccessorFunc( PANEL, "m_pOpenSubMenu", 		"OpenSubMenu" )
 
 
---[[---------------------------------------------------------
-	Init
------------------------------------------------------------]]
 function PANEL:Init()
 
 	self:SetIsMenu( true )
@@ -32,17 +18,15 @@ function PANEL:Init()
 	self:SetDrawOnTop( true )
 	self:SetMaxHeight( ScrH() * 0.9 )
 	self:SetDeleteSelf( true )
-		
+	
 	self:SetPadding( 0 )
+	self.RadioGroup = {}
 	
 	-- Automatically remove this panel when menus are to be closed
 	RegisterDermaMenuForClose( self )
 
 end
 
---[[---------------------------------------------------------
-	AddPanel
------------------------------------------------------------]]
 function PANEL:AddPanel( pnl )
 
 	self:AddItem( pnl )
@@ -50,9 +34,6 @@ function PANEL:AddPanel( pnl )
 	
 end
 
---[[---------------------------------------------------------
-	AddOption
------------------------------------------------------------]]
 function PANEL:AddOption( strText, funcFunction )
 
 	local pnl = vgui.Create( "DMenuOption", self )
@@ -66,9 +47,18 @@ function PANEL:AddOption( strText, funcFunction )
 
 end
 
---[[---------------------------------------------------------
-	AddCVar
------------------------------------------------------------]]
+function PANEL:AddRadioButton( anyGroupId, strText, funcFunction )
+
+	local pnl = self:AddOption( strText, funcFunction )
+	pnl:SetRadioGroup( anyGroupId )
+	
+	self.RadioGroup[ anyGroupId ] = self.RadioGroup[ anyGroupId ] or {}
+	table.insert( self.RadioGroup[ anyGroupId ], pnl )
+	
+	return pnl
+
+end
+
 function PANEL:AddCVar( strText, convar, on, off, funcFunction )
 
 	local pnl = vgui.Create( "DMenuOptionCVar", self )
@@ -86,9 +76,6 @@ function PANEL:AddCVar( strText, convar, on, off, funcFunction )
 
 end
 
---[[---------------------------------------------------------
-	AddSpacer
------------------------------------------------------------]]
 function PANEL:AddSpacer( strText, funcFunction )
 
 	local pnl = vgui.Create( "DPanel", self )
@@ -104,9 +91,6 @@ function PANEL:AddSpacer( strText, funcFunction )
 
 end
 
---[[---------------------------------------------------------
-	AddSubMenu
------------------------------------------------------------]]
 function PANEL:AddSubMenu( strText, funcFunction )
 
 	local pnl = vgui.Create( "DMenuOption", self )
@@ -121,9 +105,6 @@ function PANEL:AddSubMenu( strText, funcFunction )
 
 end
 
---[[---------------------------------------------------------
-	Hide
------------------------------------------------------------]]
 function PANEL:Hide()
 
 	local openmenu = self:GetOpenSubMenu()
@@ -136,9 +117,6 @@ function PANEL:Hide()
 	
 end
 
---[[---------------------------------------------------------
-	OpenSubMenu
------------------------------------------------------------]]
 function PANEL:OpenSubMenu( item, menu )
 
 	-- Do we already have a menu open?
@@ -162,10 +140,6 @@ function PANEL:OpenSubMenu( item, menu )
 
 end
 
-
---[[---------------------------------------------------------
-	CloseSubMenu
------------------------------------------------------------]]
 function PANEL:CloseSubMenu( menu )
 
 	menu:Hide()
@@ -173,9 +147,6 @@ function PANEL:CloseSubMenu( menu )
 
 end
 
---[[---------------------------------------------------------
-	Paint
------------------------------------------------------------]]
 function PANEL:Paint( w, h )
 
 	if ( !self:GetDrawBackground() ) then return end
@@ -193,9 +164,6 @@ function PANEL:GetChild( num )
 	return self:GetCanvas():GetChildren()[ num ]
 end
 
---[[---------------------------------------------------------
-	PerformLayout
------------------------------------------------------------]]
 function PANEL:PerformLayout()
 
 	local w = self:GetMinimumWidth()
@@ -261,22 +229,29 @@ function PANEL:Open( x, y, skipanimation, ownerpanel )
 	
 	self:SetSize( w, h )
 	
-	
 	if ( y + h > ScrH() ) then y = ((maunal and ScrH()) or (y + OwnerHeight)) - h end
 	if ( x + w > ScrW() ) then x = ((maunal and ScrW()) or x) - w end
 	if ( y < 1 ) then y = 1 end
 	if ( x < 1 ) then x = 1 end
 	
 	self:SetPos( x, y )
-	
-	-- Popup!
 	self:MakePopup()
-	
-	-- Make sure it's visible!
 	self:SetVisible( true )
-	
-	-- Keep the mouse active while the menu is visible.
 	self:SetKeyboardInputEnabled( false )
+	
+end
+
+function PANEL:SetRadioGroupSelected( groupIndex, pnl )
+	
+	if self.RadioGroup[ groupIndex ] then
+		
+		for k, v in pairs( self.RadioGroup[ groupIndex ] ) do
+			
+			v:SetChecked( v == pnl )
+			
+		end
+		
+	end
 	
 end
 
@@ -284,6 +259,12 @@ end
 -- Called by DMenuOption
 --
 function PANEL:OptionSelectedInternal( option )
+	
+	if ( option:GetRadioGroup() ) then
+		
+		self:SetRadioGroupSelected( option:GetRadioGroup(), option )
+		
+	end
 
 	self:OptionSelected( option, option:GetText() )
 
@@ -313,9 +294,6 @@ function PANEL:HighlightItem( item )
 
 end
 
---[[---------------------------------------------------------
-   Name: GenerateExample
------------------------------------------------------------]]
 function PANEL:GenerateExample( ClassName, PropertySheet, Width, Height )
 
 	local MenuItemSelected = function()

--- a/garrysmod/lua/vgui/dmenuoption.lua
+++ b/garrysmod/lua/vgui/dmenuoption.lua
@@ -1,23 +1,10 @@
---[[   _                                
-    ( )                               
-   _| |   __   _ __   ___ ___     _ _ 
- /'_` | /'__`\( '__)/' _ ` _ `\ /'_` )
-( (_| |(  ___/| |   | ( ) ( ) |( (_| |
-`\__,_)`\____)(_)   (_) (_) (_)`\__,_) 
-
-	DMenuOption
-
---]]
-
 local PANEL = {}
 
 AccessorFunc( PANEL, "m_pMenu", 		"Menu" )
 AccessorFunc( PANEL, "m_bChecked", 		"Checked" )
 AccessorFunc( PANEL, "m_bCheckable", 	"IsCheckable" )
+AccessorFunc( PANEL, "m_RadioGroup", 	"RadioGroup" )
 
---[[---------------------------------------------------------
-
------------------------------------------------------------]]
 function PANEL:Init()
 
 	self:SetContentAlignment( 4 )
@@ -27,10 +14,6 @@ function PANEL:Init()
 
 end
 
-
---[[---------------------------------------------------------
-
------------------------------------------------------------]]
 function PANEL:SetSubMenu( menu )
 
 	self.SubMenu = menu	
@@ -44,9 +27,6 @@ function PANEL:SetSubMenu( menu )
 	
 end
 
---
--- AddSubMenu
---
 function PANEL:AddSubMenu()
 
 	local SubMenu = DermaMenu( self )
@@ -59,11 +39,9 @@ function PANEL:AddSubMenu()
 
 end
 
-
---[[---------------------------------------------------------
-
------------------------------------------------------------]]
 function PANEL:OnCursorEntered()
+	
+	if ( self:GetDisabled() ) then return end
 
 	if ( IsValid( self.ParentMenu ) ) then
 		self.ParentMenu:OpenSubMenu( self, self.SubMenu )	
@@ -74,87 +52,81 @@ function PANEL:OnCursorEntered()
 	
 end
 
---[[---------------------------------------------------------
-
------------------------------------------------------------]]
 function PANEL:OnCursorExited()
 
 end
 
-
-
---[[---------------------------------------------------------
-
------------------------------------------------------------]]
 function PANEL:Paint( w, h )
 
 	derma.SkinHook( "Paint", "MenuOption", self, w, h )
-	
-	--
+
 	-- Draw the button text
-	--
 	return false
 
 end
 
---[[---------------------------------------------------------
-	OnMousePressed
------------------------------------------------------------]]
 function PANEL:OnMousePressed( mousecode )
-
+	
+	if ( self:GetDisabled() ) then return end
+	
 	self.m_MenuClicking = true
-
+	
 	DButton.OnMousePressed( self, mousecode )
-
+	
 end
 
---[[---------------------------------------------------------
-	OnMouseReleased
------------------------------------------------------------]]
 function PANEL:OnMouseReleased( mousecode )
-
+	
+	if ( self:GetDisabled() ) then return end
+	
 	DButton.OnMouseReleased( self, mousecode )
-
+	
 	if ( self.m_MenuClicking && mousecode == MOUSE_LEFT ) then
 		
 		self.m_MenuClicking = false
 		CloseDermaMenus()
 		
 	end
-
+	
+	if ( self.m_MenuClicking && mousecode == MOUSE_RIGHT ) then
+		
+		self.m_MenuClicking = false
+		self:DoClick()
+		
+	end
+	
 end
 
---[[---------------------------------------------------------
-	DoRightClick
------------------------------------------------------------]]
 function PANEL:DoRightClick()
-
+	
+	if ( self:GetDisabled() ) then return end
+	
 	if ( self:GetIsCheckable() ) then
 		self:ToggleCheck()
+	end
+	
+	if ( self:GetRadioGroup() ) then
+		self:DoClickInternal()
 	end
 
 end
 
---[[---------------------------------------------------------
-	DoClickInternal
------------------------------------------------------------]]
 function PANEL:DoClickInternal()
-
+	
+	if ( self:GetDisabled() ) then return end
+	
 	if ( self:GetIsCheckable() ) then
 		self:ToggleCheck()
 	end
-
+	
 	if ( self.m_pMenu ) then
 	
 		self.m_pMenu:OptionSelectedInternal( self )
 	
 	end
-
+	
 end
 
---[[---------------------------------------------------------
-	ToggleCheck
------------------------------------------------------------]]
 function PANEL:ToggleCheck()
 
 	self:SetChecked( !self:GetChecked() )
@@ -162,16 +134,10 @@ function PANEL:ToggleCheck()
 
 end
 
---[[---------------------------------------------------------
-	OnChecked
------------------------------------------------------------]]
 function PANEL:OnChecked( b )
 
 end
 
---[[---------------------------------------------------------
-   Name: PerformLayout
------------------------------------------------------------]]
 function PANEL:PerformLayout()
 
 	self:SizeToContents()
@@ -191,6 +157,14 @@ function PANEL:PerformLayout()
 
 	DButton.PerformLayout( self )
 		
+end
+
+function PANEL:UpdateColours( skin )
+
+	if ( self:GetDisabled() ) then return self:SetTextColor( skin.Colours.Button.Disabled ) end
+
+	return self:SetTextColor( skin.Colours.Button.Normal )
+
 end
 
 function PANEL:GenerateExample()


### PR DESCRIPTION
DMenu:
```lua
DMenu:AddRadioButton( anyGroupId, strText, funcFunction ) -- returns button
DMenu:SetRadioGroupSelected( groupIndex, pnl ) -- Internal
```

DMenuOption:
* Now calls DoClick() on right click without closing the menu (left click unchanged)
```lua
-- Added support for DLabel's
DMenuOption:SetDisabled( bool )
DMenuOption:SetEnabled( bool )

-- Added for radio buttons
DMenuOption:[G/S]etRadioGroup( index ) --> get/set the option's radio group
DMenuOption:UpdateColours( skin ) --> correctly update the colors on state changes
```

Default skin:
* Enabled radio button textures

Example to use the radio buttons:
```lua
local MyButton = vgui.Create( "DButton", Frame )
MyButton:Dock( FILL )

local menu = DermaMenu()
menu:SetDeleteSelf( false )
menu:SetDrawColumn( true )
menu:Hide()

local IconsSizeGroup = "Icons" -- group id can be any type

menu:AddRadioButton( IconsSizeGroup, "Big icons", function() print( "a" ) end ):SetChecked( true )
menu:AddRadioButton( IconsSizeGroup, "Medium Icons", function() print( "b" ) end )
menu:AddRadioButton( IconsSizeGroup, "Small Icons", function() print( "c" ) end )

menu:AddSpacer()

menu:AddOption( "Re-organize icons", function() print( "re-organize" ) end )

MyButton.DoClick = function()
    menu:Open()
end

MyButton.OnRemove = function()
	menu:Remove()
end
```
![Result](http://i.imgur.com/ItYsUOB.gif)