### PR TITLE
Use PlayerModel colouring for TTT players

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -259,14 +259,13 @@ end
 
 function GM:TTTPlayerSetColor(ply)
    local clr = COLOR_WHITE
-   local should_color = hook.Call("TTTShouldColorModel", GAMEMODE, ply:GetModel())
-   if GAMEMODE.playercolor and should_color then
+   if GAMEMODE.playercolor then
       -- If this player has a colorable model, always use the same color as all
       -- other colorable players, so color will never be the factor that lets
       -- you tell players apart.
       clr = GAMEMODE.playercolor
    end
-   ply:SetColor(clr)
+   ply:SetPlayerColor( Vector( clr.r/255.0, clr.g/255.0, clr.b/255.0 ) )
 end
 
 

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -110,15 +110,6 @@ function GetRandomPlayerModel()
    return table.Random(ttt_playermodels)
 end
 
-function GM:TTTShouldColorModel(mdl)
-   local colorable =  {
-      "models/player/phoenix.mdl",
-      "models/player/guerilla.mdl",
-      "models/player/leet.mdl"
-   };
-   return table.HasValue(colorable, mdl)
-end
-
 local ttt_playercolors = {
    all = {
       COLOR_WHITE,
@@ -147,16 +138,14 @@ local ttt_playercolors = {
 
 CreateConVar("ttt_playercolor_mode", "1")
 function GM:TTTPlayerColor(model)
-   if hook.Call("TTTShouldColorModel", GAMEMODE, model) then
-      local mode = GetConVarNumber("ttt_playercolor_mode") or 0
-      if mode == 1 then
-         return table.Random(ttt_playercolors.serious)
-      elseif mode == 2 then
-         return table.Random(ttt_playercolors.all)
-      elseif mode == 3 then
-         -- Full randomness
-         return Color(math.random(0, 255), math.random(0, 255), math.random(0, 255))
-      end
+   local mode = GetConVarNumber("ttt_playercolor_mode") or 0
+   if mode == 1 then
+      return table.Random(ttt_playercolors.serious)
+   elseif mode == 2 then
+      return table.Random(ttt_playercolors.all)
+   elseif mode == 3 then
+      -- Full randomness
+      return Color(math.random(0, 255), math.random(0, 255), math.random(0, 255))
    end
    -- No coloring
    return COLOR_WHITE


### PR DESCRIPTION
Removes the need for checking if a playermodel is colourable as it uses GMod 13's matproxy player colouring. 