### PR TITLE
Fixed Fullbright/Missing Materials in VBSP and in-game

### DIFF
--- a/garrysmod/gameinfo.txt
+++ b/garrysmod/gameinfo.txt
@@ -28,7 +28,7 @@
 
 			platform			|all_source_engine_paths|platform/platform_misc.vpk
 
-			mod+mod_write+default_write_path		|gameinfo_path|.
+			game+mod_write+default_write_path		|gameinfo_path|.
 
 			game+game_write		garrysmod
 


### PR DESCRIPTION
This modifcation to gameinfo.txt fixes materials that would be falsely reported as "not found" in VBSP. In relation to this, materials will not appear fullbright in-game.
Before: 
```
Valve Software - vbsp.exe (Apr 22 2014)
nocubemap = true
4 threads
materialPath: C:\Program Files (x86)\Steam\SteamApps\common\GarrysMod\garrysmod\materials
Loading c:\program files (x86)\steam\steamapps\common\garrysmod\garrysmod\maps\dice_rooftops.vmf
material "materials/tools/toolsskybox" not found.
Material not found!: MATERIALS/TOOLS/TOOLSSKYBOX
ConVarRef mat_reduceparticles doesn't point to an existing ConVar
material "dice/buildings/m_c_02_facade_02" not found.
Material not found!: DICE/BUILDINGS/M_C_02_FACADE_02
material "materials/tools/toolsnodraw" not found.
Material not found!: MATERIALS/TOOLS/TOOLSNODRAW
material "dice/rooftops/t_roof_02" not found.
Material not found!: DICE/ROOFTOPS/T_ROOF_02
Could not locate 'GameData' key in c:\program files (x86)\steam\steamapps\common\garrysmod\garrysmod\gameinfo.txt
fixing up env_cubemap materials on brush sides...
```

After:
```
Valve Software - vbsp.exe (Apr 22 2014)
nocubemap = true
4 threads
materialPath: C:\Program Files (x86)\Steam\SteamApps\common\GarrysMod\garrysmod\materials
Loading c:\program files (x86)\steam\steamapps\common\garrysmod\garrysmod\maps\dice_rooftops.vmf
ConVarRef mat_reduceparticles doesn't point to an existing ConVar
Could not locate gameinfo.txt for Instance Remapping at gameinfo.txt
fixing up env_cubemap materials on brush sides...
```