### PR TITLE
Optimized Panel:IsChildHovered()

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -117,7 +117,7 @@ function PANEL:Paint( w, h )
 
 	surface.SetDrawColor( 255, 255, 255, 255 )
 	
-	if ( !dragndrop.IsDragging() && (self:IsHovered() || self:IsChildHovered( 2 )) ) then
+	if ( !dragndrop.IsDragging() && (self:IsHovered() || self:IsChildHovered()) ) then
 
 		surface.SetMaterial( matOverlay_Hovered )
 		self.Label:Hide()

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -545,19 +545,12 @@ function meta:Hide()
 	self:SetVisible( false )
 end
 
-function meta:IsChildHovered( iDepth )
+function meta:IsChildHovered()
 
 	local Hovered = vgui.GetHoveredPanel()
 	if ( !IsValid( Hovered ) ) then return false end
+	if ( Hovered == self ) then return false end
 
-	for i = 1, iDepth do
-
-		Hovered = Hovered:GetParent()
-		if ( !IsValid( Hovered ) ) then return false end
-		if ( Hovered == self ) then return true end
-
-	end
-
-	return false
+	return Hovered:HasParent( self )
 
 end

--- a/garrysmod/lua/vgui/prop_combo.lua
+++ b/garrysmod/lua/vgui/prop_combo.lua
@@ -35,7 +35,7 @@ function PANEL:Setup( vars )
 	
 	combo.Paint = function( combo, w, h )
 		
-		if self:IsEditing() or self:GetRow():IsHovered() or self:GetRow():IsChildHovered( 6 ) then
+		if self:IsEditing() or self:GetRow():IsHovered() or self:GetRow():IsChildHovered() then
 			DComboBox.Paint( combo, w, h )
 		end
 		

--- a/garrysmod/lua/vgui/prop_float.lua
+++ b/garrysmod/lua/vgui/prop_float.lua
@@ -61,7 +61,7 @@ function PANEL:Setup( vars )
 	self.Paint = function()
 
 		-- PERFORMANCE !!!
-		ctrl.Slider:SetVisible( self:IsEditing() || self:GetRow():IsChildHovered( 6 ) )
+		ctrl.Slider:SetVisible( self:IsEditing() || self:GetRow():IsChildHovered() )
 
 	end
 


### PR DESCRIPTION
Removed the iDepth parameter, no longer needed.
All instances using the parameter are corrected.