### PR TITLE
Fixed Magneto Stick setting nil Owner on active SWEP

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -103,10 +103,12 @@ function SWEP:Reset(keep_velocity)
    end
 
    if IsValid(self.EntHolding) then
-      if not IsValid(self.PrevOwner) then
-         self.EntHolding:SetOwner(nil)
-      else
-         self.EntHolding:SetOwner(self.PrevOwner)
+      if not self.EntHolding:IsWeapon() then
+         if not IsValid(self.PrevOwner) then
+            self.EntHolding:SetOwner(nil)
+         else
+            self.EntHolding:SetOwner(self.PrevOwner)
+         end
       end
 
       -- the below ought to be unified with self:Drop()

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -103,6 +103,8 @@ function SWEP:Reset(keep_velocity)
    end
 
    if IsValid(self.EntHolding) then
+      -- it is possible for weapons to be already equipped at this point
+      -- changing the owner in such a case would cause problems
       if not self.EntHolding:IsWeapon() then
          if not IsValid(self.PrevOwner) then
             self.EntHolding:SetOwner(nil)
@@ -372,9 +374,12 @@ function SWEP:Pickup()
 
          -- if we already are owner before pickup, we will not want to disown
          -- this entity when we drop it
-         self.PrevOwner = self.EntHolding:GetOwner()
+         -- weapons should not have their owner changed in this way
+         if not self.EntHolding:IsWeapon() then
+            self.PrevOwner = self.EntHolding:GetOwner()
 
-         self.EntHolding:SetOwner(ply)
+            self.EntHolding:SetOwner(ply)
+         end
 
          local phys = self.CarryHack:GetPhysicsObject()
          if IsValid(phys) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -369,6 +369,9 @@ function SWEP:Pickup()
          self.CarryHack:SetOwner(ply)
          self.CarryHack:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
          self.CarryHack:SetSolid(SOLID_NONE)
+         
+         -- set the desired angles before adding the constraint
+         self.CarryHack:SetAngles(self.Owner:GetAngles())
 
          self.CarryHack:Spawn()
 


### PR DESCRIPTION
Prevents the Magneto Stick from resetting a SWEP's Owner after being dropped.

It is possible to equip a weapon while holding it with the stick. Previously this prevented the weapon from being used properly and caused script errors. The player would need to equip the weapon again after dropping it to solve the issue.