### PR TITLE
TTT: Fixed spectators having footstep sounds

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -153,7 +153,7 @@ end
 
 -- Kill footsteps on player and client
 function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
-   if IsValid(ply) and (ply:Crouching() or ply:GetMaxSpeed() < 150) then
+   if IsValid(ply) and (ply:Crouching() or ply:GetMaxSpeed() < 150 or ply:IsSpec()) then
       -- do not play anything, just prevent normal sounds from playing
       return true
    end


### PR DESCRIPTION
Dead players sometimes play footstep sounds. Not sure exactly why but this solves that.

Perhaps it has something to do with some spectators being reported as technically 'alive' while in spectator mode if I remember correctly.