### PR TITLE
TTT: Fixed Decoy's radar color

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -186,7 +186,7 @@ function RADAR:Draw(client)
          surface.SetDrawColor(0, 0, 255, alpha)
          surface.SetTextColor(0, 0, 255, alpha)
 
-      elseif role == -1 then -- decoys
+      elseif role == 3 then -- decoys
          surface.SetDrawColor(150, 150, 150, alpha)
          surface.SetTextColor(150, 150, 150, alpha)
 


### PR DESCRIPTION
The client was looking for a "-1" when it was actually reading a "3" from the network message. When the networking functions were updated it's likely that this was broken and then overlooked as a "-1" is actually sent by the server but not received as intended.

Not the most thorough edit but now the radar will properly display decoys to traitors just as before.