### PR TITLE
TTT: Sped up weapon scrolling

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -17,7 +17,7 @@ WSWITCH.cv = {}
 WSWITCH.cv.stay = CreateConVar("ttt_weaponswitcher_stay", "0", FCVAR_ARCHIVE)
 WSWITCH.cv.fast = CreateConVar("ttt_weaponswitcher_fast", "0", FCVAR_ARCHIVE)
 
-local delay = 0.075
+local delay = 0.03
 local showtime = 3
 
 local margin = 10


### PR DESCRIPTION
The default speed feels very sluggish in my opinion. I can understand a slight delay to prevent multiple scrolls at once but the previous value felt more like an arbitrary limitation that did not improve the quality of the game. I haven't heard any complaints about the length of delay being proposed here even with at least a year of testing from different communities.

If there's a problem with this change such as something technical I would not mind creating a convar and adding a menu option to allow a custom setting so that the few negatively impacted by this new delay won't suffer. I haven't encountered anyone like that however.