### PR TITLE
TTT: Fixed Rifle scope, zoom spread, unscope delay

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -44,53 +44,63 @@ SWEP.IronSightsPos      = Vector( 5, -15, -2 )
 SWEP.IronSightsAng      = Vector( 2.6, 1.37, 3.5 )
 
 function SWEP:SetZoom(state)
-    if CLIENT then
-       return
-    elseif IsValid(self.Owner) and self.Owner:IsPlayer() then
-       if state then
-          self.Owner:SetFOV(20, 0.3)
-       else
-          self.Owner:SetFOV(0, 0.2)
-       end
-    end
+   if CLIENT then
+      return
+   elseif IsValid(self.Owner) and self.Owner:IsPlayer() then
+      if state then
+         self.Owner:SetFOV(20, 0.3)
+      else
+         self.Owner:SetFOV(0, 0.2)
+      end
+   end
+end
+
+function SWEP:PrimaryAttack( worldsnd )
+   self.BaseClass.PrimaryAttack( self.Weapon, worldsnd )
+   self:SetNextSecondaryFire( CurTime() + 0.1 )
 end
 
 -- Add some zoom to ironsights for this gun
 function SWEP:SecondaryAttack()
-    if not self.IronSightsPos then return end
-    if self:GetNextSecondaryFire() > CurTime() then return end
+   if not self.IronSightsPos then return end
+   if self:GetNextSecondaryFire() > CurTime() then return end
 
-    local bIronsights = not self:GetIronsights()
+   local bIronsights = not self:GetIronsights()
 
-    self:SetIronsights( bIronsights )
+   self:SetIronsights( bIronsights )
 
-    if SERVER then
-        self:SetZoom(bIronsights)
-     else
-        self:EmitSound(self.Secondary.Sound)
-    end
+   if SERVER then
+      self:SetZoom(bIronsights)
+   else
+      self:EmitSound(self.Secondary.Sound)
+   end
 
-    self:SetNextSecondaryFire( CurTime() + 0.3)
+   self:SetNextSecondaryFire( CurTime() + 0.3)
+end
+
+function SWEP:GetPrimaryCone()
+   -- we should be perfectly accurate while zooming
+   return self:GetIronsights() and 0 or self.Primary.Cone
 end
 
 function SWEP:PreDrop()
-    self:SetZoom(false)
-    self:SetIronsights(false)
-    return self.BaseClass.PreDrop(self)
+   self:SetZoom(false)
+   self:SetIronsights(false)
+   return self.BaseClass.PreDrop(self)
 end
 
 function SWEP:Reload()
 	if ( self:Clip1() == self.Primary.ClipSize or self.Owner:GetAmmoCount( self.Primary.Ammo ) <= 0 ) then return end
-    self:DefaultReload( ACT_VM_RELOAD )
-    self:SetIronsights( false )
-    self:SetZoom( false )
+   self:DefaultReload( ACT_VM_RELOAD )
+   self:SetIronsights( false )
+   self:SetZoom( false )
 end
 
 
 function SWEP:Holster()
-    self:SetIronsights(false)
-    self:SetZoom(false)
-    return true
+   self:SetIronsights(false)
+   self:SetZoom(false)
+   return true
 end
 
 if CLIENT then
@@ -98,10 +108,13 @@ if CLIENT then
    function SWEP:DrawHUD()
       if self:GetIronsights() then
          surface.SetDrawColor( 0, 0, 0, 255 )
+         
+         local scrW = ScrW()
+         local scrH = ScrH()
 
-         local x = ScrW() / 2.0
-         local y = ScrH() / 2.0
-         local scope_size = ScrH()
+         local x = scrW / 2.0
+         local y = scrH / 2.0
+         local scope_size = scrH
 
          -- crosshair
          local gap = 80
@@ -124,6 +137,10 @@ if CLIENT then
          local w = (x - sh) + 2
          surface.DrawRect(0, 0, w, scope_size)
          surface.DrawRect(x + sh - 2, 0, w, scope_size)
+         
+         -- cover gaps on top and bottom of screen
+         surface.DrawLine( 0, 0, scrW, 0 )
+         surface.DrawLine( 0, scrH - 1, scrW, scrH - 1 )
 
          surface.SetDrawColor(255, 0, 0, 255)
          surface.DrawLine(x, y, x + 1, y + 1)
@@ -133,7 +150,6 @@ if CLIENT then
          surface.SetDrawColor(255, 255, 255, 255)
 
          surface.DrawTexturedRectRotated(x, y, scope_size, scope_size, 0)
-
       else
          return self.BaseClass.DrawHUD(self)
       end

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -78,11 +78,6 @@ function SWEP:SecondaryAttack()
    self:SetNextSecondaryFire( CurTime() + 0.3)
 end
 
-function SWEP:GetPrimaryCone()
-   -- we should be perfectly accurate while zooming
-   return self:GetIronsights() and 0 or self.Primary.Cone
-end
-
 function SWEP:PreDrop()
    self:SetZoom(false)
    self:SetIronsights(false)


### PR DESCRIPTION
There were two gaps when zoomed in with the rifle on the top and bottom of the screen respectively. Fixed by drawing two lines on the top and bottom of the screen.

It was also possible to miss a well aimed shot with the sniper rifle while scoped previously, though it would be a rare occurrence surely. Fixed by removing all spread while scoped.

In the default weapon base, when the weapon is fired it will delay both its primary and secondary attack by the value of the primary attack. This is just fine for weapons that fire relatively quickly but having to wait a second and a half each time you fire the rifle to unzoom seems like an oversight instead of a conscious design choice especially considering the fact that you can switch weapons freely while this is happening. Feels very clunky. Gave it an 0.1 secondary fire delay after shooting. Should be friendly with weapon base updates/customizations too.

Corrected some tabbing inconsistencies.