### PR TITLE
Fixed nil value error when no command is passed

### DIFF
--- a/garrysmod/lua/includes/modules/concommand.lua
+++ b/garrysmod/lua/includes/modules/concommand.lua
@@ -47,7 +47,11 @@ end
    Desc: Called by the engine when an unknown console command is run
 -----------------------------------------------------------]]
 function Run( player, command, arguments, args )
-
+	
+	if ( command == nil ) then
+		return false
+	end
+	
 	local LowerCommand = string.lower( command )
 
 	if ( CommandList[ LowerCommand ] != nil ) then


### PR DESCRIPTION
Fixes the following serverside error when executing the `` _u `` command without any arguments:

````
[ERROR] lua/includes/modules/concommand.lua:51: bad argument #1 to 'lower' (string expected, got nil)
  1. lower - [C]:-1
   2. Run - lua/includes/modules/concommand.lua:51
    3. unknown - addons/ulib/lua/ulib/shared/commands.lua:1310
     4. unknown - lua/includes/modules/concommand.lua:54
````