### PR TITLE
TTT: Fixed C4 beeps not playing through some walls 

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -330,7 +330,6 @@ function ENT:IsDetectiveNear()
    return false
 end
 
-//local beep = Sound("weapons/c4/c4_beep1.wav")
 local MAX_MOVE_RANGE = 1000000 -- sq of 1000
 function ENT:Think()
    if not self:GetArmed() then return end
@@ -382,7 +381,6 @@ function ENT:Think()
 
       if SERVER then
          -- send the sound manually to prevent culling
-         //sound.Play(beep, self:GetPos(), amp, 100)
          self:SendBeepSound(self:GetPos(), amp)
       end
 

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -391,6 +391,10 @@ function ENT:Think()
    end
 end
 
+function ENT:Defusable()
+   return self:GetArmed()
+end
+
 -- Timer configuration handlign
 
 if SERVER then


### PR DESCRIPTION
I assume the reason this happened before is the culling done to prevent unnecessary network information from being sent. Unfortunately, hearing something on the other side of a wall that's about to kill you is necessary in my opinion. It's seems that this isn't an intended feature as there are many times that the C4 is well out of reach but still within your PVS.

To test the difference plant a C4 in that infamous spot underground between the two houses on dm_richland. Before you wouldn't be able to hear it but now you will.

I'm not very familiar with using ints/uints in networking so if someone has advice to make this more efficient I'd appreciate it. Already did a bit of optimization which should be enough.
