### PR TITLE
Fixed OnChatTab duplicating characters in base gamemode

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -177,8 +177,10 @@ end
 -----------------------------------------------------------]]
 function GM:OnChatTab( str )
 
+	str = string.TrimRight(str)
+	
 	local LastWord
-	for word in string.gmatch( str, "%a+" ) do
+	for word in string.gmatch( str, "[^ ]+" ) do
 		LastWord = word
 	end
 


### PR DESCRIPTION
Using the name "my_hat_stinks" as an example, both "my " and "my_" would result in "mmy_hat_stinks".
The first issue is fixed by simply removing extra space characters. The second issue by allowing punctuation to be included in "LastWord". This is simpler and easier than finding the exact location of LastWord and replacing only those characters.
This also has the side effect of accepting names containing non-alphabetic characters.