### PR TITLE
TTT: Weapon base adds view punch to bullet dir

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -305,7 +305,7 @@ function SWEP:ShootBullet( dmg, recoil, numbul, cone )
    local bullet = {}
    bullet.Num    = numbul
    bullet.Src    = self.Owner:GetShootPos()
-   bullet.Dir    = self.Owner:GetAimVector()
+   bullet.Dir    = (self.Owner:GetAimVector():Angle() + self.Owner:GetPunchAngle()):Forward()
    bullet.Spread = Vector( cone, cone, 0 )
    bullet.Tracer = 4
    bullet.TracerName = self.Tracer or "Tracer"

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -246,6 +246,7 @@ function SWEP:PrimaryAttack(worldsnd)
    local owner = self.Owner
    if not IsValid(owner) or owner:IsNPC() or (not owner.ViewPunch) then return end
 
+   math.randomseed( self:Clip1() * self.Primary.Recoil * self.Primary.ClipSize )
    owner:ViewPunch( Angle( math.Rand(-0.2,-0.1) * self.Primary.Recoil, math.Rand(-0.1,0.1) *self.Primary.Recoil, 0 ) )
 end
 


### PR DESCRIPTION
Bullets fired did not previously consider the view punch added from firing the weapon, meaning that the center of the cone did not line up with the camera. This was fairly noticeable on weapons with a lot of recoil and/or a fast fire rate.

This edit better reflects the direction that the player is looking.
