### PR TITLE
TTT: Allow detectives to reequip their dropped hat

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -5,6 +5,8 @@ ENT.Type = "anim"
 ENT.Base = "base_anim"
 
 ENT.Model = Model("models/ttt/deerstalker.mdl")
+ENT.CanHavePrints = false
+ENT.CanUseKey = true
 
 AccessorFuncDT(ENT, "worn", "BeingWorn")
 
@@ -33,6 +35,8 @@ function ENT:Initialize()
 end
 
 if SERVER then
+   local ttt_hats_reclaim = CreateConVar("ttt_detective_hats_reclaim", "1")
+
    function ENT:OnRemove()
       self:SetBeingWorn(false)
    end
@@ -44,6 +48,7 @@ if SERVER then
       self:SetParent(nil)
 
       self:SetBeingWorn(false)
+      self:SetUseType(SIMPLE_USE)
 
       -- only now physics this entity
       self:PhysicsInit(SOLID_VPHYSICS)
@@ -84,6 +89,32 @@ if SERVER then
 
          phys:Wake()
       end
+   end
+
+   function ENT:UseOverride( ply )
+      if !IsValid(ply) or ply:IsSpec() or self:GetBeingWorn() then return end
+
+      if GetRoundState() != ROUND_ACTIVE then
+         SafeRemoveEntity(self)
+         return
+      elseif ply:GetRole() != ROLE_DETECTIVE or IsValid(ply.hat) then
+         return
+      end
+
+      sound.Play("weapon.ImpactSoft", self:GetPos(), 75, 100, 1)
+
+      self:SetMoveType(MOVETYPE_NONE)
+      self:SetSolid(SOLID_NONE)
+      self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+
+      self:SetParent(ply)
+      self.Wearer = ply
+
+      ply.hat = self.Entity
+
+      self:SetBeingWorn(true)
+
+      //LANG.Msg(activator, "hat_retrieve")
    end
 
    local function TestHat(ply, cmd, args)

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -115,7 +115,7 @@ if SERVER then
    
          self:SetBeingWorn(true)
    
-         //LANG.Msg(activator, "hat_retrieve")
+         LANG.Msg(activator, "hat_retrieve")
       end
    end
 

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -36,6 +36,7 @@ end
 
 if SERVER then
    local ttt_hats_reclaim = CreateConVar("ttt_detective_hats_reclaim", "1")
+   local ttt_hats_innocent = CreateConVar("ttt_detective_hats_reclaim_any", "0")
 
    function ENT:OnRemove()
       self:SetBeingWorn(false)
@@ -91,14 +92,19 @@ if SERVER then
       end
    end
 
-   function ENT:UseOverride( ply )
+   local function CanEquipHat(ply)
+      return not IsValid(ply.hat) and
+         (ttt_hats_innocent:GetBool() or ply:GetRole() == ROLE_DETECTIVE)
+   end
+
+   function ENT:UseOverride(ply)
       if not ttt_hats_reclaim:GetBool() then return end
       
       if IsValid(ply) and not self:GetBeingWorn() then
          if GetRoundState() != ROUND_ACTIVE then
             SafeRemoveEntity(self)
             return
-         elseif ply:GetRole() != ROLE_DETECTIVE or IsValid(ply.hat) then
+         elseif not CanEquipHat(ply) then
             return
          end
    

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -92,29 +92,31 @@ if SERVER then
    end
 
    function ENT:UseOverride( ply )
-      if !IsValid(ply) or ply:IsSpec() or self:GetBeingWorn() then return end
-
-      if GetRoundState() != ROUND_ACTIVE then
-         SafeRemoveEntity(self)
-         return
-      elseif ply:GetRole() != ROLE_DETECTIVE or IsValid(ply.hat) then
-         return
+      if not ttt_hats_reclaim:GetBool() then return end
+      
+      if IsValid(ply) and not self:GetBeingWorn() then
+         if GetRoundState() != ROUND_ACTIVE then
+            SafeRemoveEntity(self)
+            return
+         elseif ply:GetRole() != ROLE_DETECTIVE or IsValid(ply.hat) then
+            return
+         end
+   
+         sound.Play("weapon.ImpactSoft", self:GetPos(), 75, 100, 1)
+   
+         self:SetMoveType(MOVETYPE_NONE)
+         self:SetSolid(SOLID_NONE)
+         self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+   
+         self:SetParent(ply)
+         self.Wearer = ply
+   
+         ply.hat = self.Entity
+   
+         self:SetBeingWorn(true)
+   
+         //LANG.Msg(activator, "hat_retrieve")
       end
-
-      sound.Play("weapon.ImpactSoft", self:GetPos(), 75, 100, 1)
-
-      self:SetMoveType(MOVETYPE_NONE)
-      self:SetSolid(SOLID_NONE)
-      self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
-
-      self:SetParent(ply)
-      self.Wearer = ply
-
-      ply.hat = self.Entity
-
-      self:SetBeingWorn(true)
-
-      //LANG.Msg(activator, "hat_retrieve")
    end
 
    local function TestHat(ply, cmd, args)

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
@@ -1059,3 +1059,6 @@ L.drop_no_ammo = "Insufficient ammo in your weapon's clip to drop as an ammo box
 --- v31
 L.set_cross_brightness = "Crosshair brightness"
 L.set_cross_size = "Crosshair size"
+
+--- v?? (05-22-15:m-d-y)
+L.hat_retrieve = "You picked up a Detective's hat."


### PR DESCRIPTION
A vital, long awaited solution that should finally solve this horse shit bug. How are we supposed to get immersed if we can't even pick our own hats back up? Who thought that was a good idea? No wonder TTT is so unpopular.

Comes with a cvar that is enabled by default. I'd send the player a text notification but I'm not sure I want to give translators any more hassle.

A slight sound is made when equipping the hat ~~which only detectives may do~~ if they are missing one for whatever reason. It doesn't have to be your own hat.

Edit: added a cvar disabled by default that allows innocents to equip hats as well.