### PR TITLE
Improved duplicator and properties support for prop_effect

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -33,7 +33,7 @@ function ENT:Initialize()
 		self.AttachedEntity:Spawn()
 		self.AttachedEntity:SetParent( self.Entity )
 		self.AttachedEntity:DrawShadow( false )
-		
+
 		self:SetModel( "models/props_junk/watermelon01.mdl" )
 	
 		self:DeleteOnRemove( self.AttachedEntity )

--- a/garrysmod/lua/autorun/properties/bodygroups.lua
+++ b/garrysmod/lua/autorun/properties/bodygroups.lua
@@ -10,6 +10,7 @@ properties.Add( "bodygroups", {
 		if ( !IsValid( ent ) ) then return false end
 		if ( ent:IsPlayer() ) then return false end
 		if ( !gamemode.Call( "CanProperty", ply, "bodygroups", ent ) ) then return false end
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end  -- If our ent has an attached entity, we want to use and modify its bodygroups instead
 
 		--
 		-- Get a list of bodygroups
@@ -31,10 +32,12 @@ properties.Add( "bodygroups", {
 
 	MenuOpen = function( self, option, ent, tr )
 
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end
+
 		--
 		-- Get a list of bodygroups
 		--
-		local options = ent:GetBodyGroups();
+		local options = ent:GetBodyGroups()
 
 		--
 		-- Add a submenu to our automatically created menu option

--- a/garrysmod/lua/autorun/properties/bone_manipulate.lua
+++ b/garrysmod/lua/autorun/properties/bone_manipulate.lua
@@ -9,6 +9,7 @@ properties.Add( "bone_manipulate", {
 	Filter = function( self, ent, ply ) 
 	
 		if ( !gamemode.Call( "CanProperty", ply, "bonemanipulate", ent ) ) then return false end
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end  -- If our ent has an attached entity, we want to use and modify its bones instead
 
 		local bonecount = ent:GetBoneCount()
 		if ( !bonecount || bonecount <= 1 ) then return false end
@@ -17,6 +18,8 @@ properties.Add( "bone_manipulate", {
 	end,
 
 	Action = function( self, ent )
+
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end
 	
 		self:MsgStart()
 			net.WriteEntity( ent )
@@ -72,11 +75,15 @@ properties.Add( "bone_manipulate_end", {
 
 	Filter = function( self, ent ) 
 
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end  -- If our ent has an attached entity, we want to use and modify its bones instead
+
 		return ents.FindByClassAndParent( "widget_bones", ent ) != nil
 
 	end,
 
 	Action = function( self, ent )
+
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end
 
 		self:MsgStart()
 			net.WriteEntity( ent )

--- a/garrysmod/lua/autorun/properties/skin.lua
+++ b/garrysmod/lua/autorun/properties/skin.lua
@@ -11,6 +11,7 @@ properties.Add( "skin", {
 		if ( !IsValid( ent ) ) then return false end
 		if ( ent:IsPlayer() ) then return false end
 		if ( !gamemode.Call( "CanProperty", ply, "skin", ent ) ) then return false end
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end  -- If our ent has an attached entity, we want to modify its skin instead
 		if ( !ent:SkinCount() ) then return false end
 
 		return ent:SkinCount() > 1
@@ -28,7 +29,8 @@ properties.Add( "skin", {
 		--
 		-- Create a check item for each skin
 		--
-		local num = ent:SkinCount();
+		local num = ent:SkinCount()
+		if ( IsValid( ent.AttachedEntity ) ) then num = ent.AttachedEntity:SkinCount() end
 
 		for i=0, num-1 do
 
@@ -44,7 +46,7 @@ properties.Add( "skin", {
 
 	Action = function( self, ent )
 
-		-- Nothing - we use SetBodyGroup below
+		-- Nothing - we use SetSkin below
 		
 	end,
 
@@ -65,6 +67,7 @@ properties.Add( "skin", {
 		if ( !self:Filter( ent, player ) ) then return end
 
 		ent:SetSkin( skinid )
+		if ( IsValid( ent.AttachedEntity ) ) then ent.AttachedEntity:SetSkin( skinid ) end
 		
 	end	
 


### PR DESCRIPTION
- Effects now save their AttachedEntity's entity modifiers, bodygroups, and bone manips when copied, and reapply them all to the AttachedEntity when pasted. Before, all of these were lost when saving.

- Fixed an issue where using the duplicator on an effect would copy the original effect's AttachedEntity value, causing anything that looks for ent.AttachedEntity to get the wrong entity. For example, if you spawned an effect, copy-pasted it with the duplicator, and then used the color tool on the new effect, it would recolor the first effect instead of the one you clicked on.

- The Skin, Bodygroup, and Bone Editor properties (context menu right-click options) now all work properly with effects - if the ent you've right-clicked on has an AttachedEntity value, the properties will use that instead.

- An effect's AttachedEntity value is now available clientside. This was necessary to get the properties working, but I'm sure other things could have a use for it too.