### PR TITLE
Apply playermodel colour to corpses/ragdolls

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -5,6 +5,8 @@ CORPSE = {}
 
 include("corpse_shd.lua")
 
+util.AddNetworkString("TTTCorpseCreated")
+
 --- networked data abstraction layer
 local dti = CORPSE.dti
 
@@ -436,6 +438,13 @@ function CORPSE.Create(ply, attacker, dmginfo)
       local efn = ply.effect_fn
       timer.Simple(0, function() efn(rag) end)
    end
+   
+   timer.Simple(0.1, function() 
+      net.Start("TTTCorpseCreated")
+         net.WriteEntity(rag)
+         net.WriteColor(GAMEMODE.playercolor)
+      net.Broadcast()
+   end, rag)
 
    return rag -- we'll be speccing this
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse_shd.lua
@@ -33,4 +33,11 @@ function CORPSE.GetCredits(rag, default)
    return rag:GetDTInt(dti.INT_CREDITS)
 end
 
-
+if CLIENT then
+   net.Receive("TTTCorpseCreated", function(len)
+      local rag = net.ReadEntity()
+      local clr = net.ReadColor()
+      clr = Vector(clr.r/255.0, clr.g/255.0, clr.b/255.0)
+      rag.GetPlayerColor = function() return clr end
+	end)
+end


### PR DESCRIPTION
Applies the playermodel colour to corpses/ragdolls in TTT. This isn't the optimal way to do it but it's the best I can do without messing too much with the corpse code.
Current TTT: Ragdolls all take the default blue colour regardless of the colour of the living players
With this change: Ragdolls maintain the colour used for playermodels this round.