### PR TITLE
Fix weapon_zm_rifle's IconLetter

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -6,7 +6,7 @@ if CLIENT then
    SWEP.PrintName          = "rifle_name"
    SWEP.Slot               = 2
    SWEP.Icon = "vgui/ttt/icon_scout"
-   SWEP.IconLetter = "r"
+   SWEP.IconLetter = "n"
 end
 
 SWEP.Base               = "weapon_tttbase"


### PR DESCRIPTION
The wiki has r and n swapped. Whereas r should be the AWP and n should be the Scout.