### PR TITLE
Fix error when spawning non-standard vehicles

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -770,7 +770,7 @@ local function MakeVehicle( Player, Pos, Ang, Model, Class, VName, VTable, data 
 	Ent:Spawn()
 	Ent:Activate()
 
-	Ent:SetVehicleClass( VName )
+	if ( Ent.SetVehicleClass && VName ) then Ent:SetVehicleClass( VName ) end
 	Ent.VehicleName = VName
 	Ent.VehicleTable = VTable
 


### PR DESCRIPTION
This includes irregular classes used by custom vehicles and trailers that do not inherit SetVehicleClass.