### PR TITLE
TTT: Player and spectator chat channels

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -82,11 +82,6 @@ function GM:PlayerBindPress(ply, bind, pressed)
             GAMEMODE.ForcedMouse = true
          end
       end
-   elseif bind == "messagemode" and pressed and ply:IsSpec() then
-      if GAMEMODE.round_state == ROUND_ACTIVE and DetectiveMode() then
-         LANG.Msg("spec_teamchat_hint")
-         return true
-      end
    elseif bind == "noclip" and pressed then
       if not GetConVar("sv_cheats"):GetBool() then
          RunConsoleCommand("ttt_equipswitch")

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -78,11 +78,22 @@ local function AddDetectiveText(ply, text)
                 ": " .. text)
 end
 
-function GM:OnPlayerChat( ply, text, teamchat, dead )
+function GM:OnPlayerChat(ply, text, teamchat, dead)
    if IsValid(ply) and ply:IsActiveDetective() then
       AddDetectiveText(ply, text)
       return true
    end
+   
+   local team = ply:Team() == TEAM_SPEC
+   
+   if team and not dead then
+      dead = true
+   end
+   
+   if teamchat and ((not team and not ply:IsSpecial()) or team) then
+      teamchat = false
+   end
+
    return self.BaseClass:OnPlayerChat(ply, text, teamchat, dead)
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -99,12 +99,11 @@ function GM:PlayerCanSeePlayersChat(text, team_only, listener, speaker)
 	local sTeam = speaker:Team() == TEAM_SPEC
 	local lTeam = listener:Team() == TEAM_SPEC
 	
-	if team_only and not sTeam and not speaker:IsSpecial() then team_only = false end
-	
 	if (GetRoundState() != ROUND_ACTIVE) or   -- Round isn't active
 	(not GetConVar("ttt_limit_spectator_chat"):GetBool()) or   -- Spectators can chat freely
 	(not DetectiveMode()) or   -- Mumbling
 	(not sTeam and ((team_only and not speaker:IsSpecial()) or (not team_only))) or   -- If someone alive talks (and not a special role in teamchat's case)
+	(not sTeam and team_only and speaker:GetRole() == listener:GetRole()) or
 	(sTeam and lTeam) then   -- If the speaker and listener are spectators
 	   return true 
 	end

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -94,7 +94,6 @@ CreateConVar("ttt_limit_spectator_voice", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 function GM:PlayerCanSeePlayersChat(text, team_only, listener, speaker)
 	if (not IsValid(listener)) or (not IsValid(speaker)) then return false end
-	if team_only and speaker:IsSpecial() and listener:IsSpecial() then return true end
 	
 	local sTeam = speaker:Team() == TEAM_SPEC
 	local lTeam = listener:Team() == TEAM_SPEC

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -4,6 +4,7 @@ local net = net
 local string = string
 local table = table
 local pairs = pairs
+local IsValid = IsValid
 
 -- NOTE: most uses of the Msg functions here have been moved to the LANG
 -- functions. These functions are essentially deprecated, though they won't be
@@ -91,54 +92,61 @@ end
 CreateConVar("ttt_limit_spectator_chat", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 CreateConVar("ttt_limit_spectator_voice", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
-local mumbles = {"mumble", "mm", "hmm", "hum", "mum", "mbm", "mble", "ham", "mammaries", "political situation", "mrmm", "hrm", "uzbekistan", "mumu", "cheese export", "hmhm", "mmh", "mumble", "mphrrt", "mrh", "hmm", "mumble", "mbmm", "hmml", "mfrrm"}
+function GM:PlayerCanSeePlayersChat(text, team_only, listener, speaker)
+	if (not IsValid(listener)) or (not IsValid(speaker)) then return false end
+	if team_only and speaker:IsSpecial() and listener:IsSpecial() then return true end
+	
+	local sTeam = speaker:Team() == TEAM_SPEC
+	local lTeam = listener:Team() == TEAM_SPEC
+	
+	if team_only and not sTeam and not speaker:IsSpecial() then team_only = false end
+	
+	if (GetRoundState() != ROUND_ACTIVE) or   -- Round isn't active
+	(not GetConVar("ttt_limit_spectator_chat"):GetBool()) or   -- Spectators can chat freely
+	(not DetectiveMode()) or   -- Mumbling
+	(not sTeam and ((team_only and not speaker:IsSpecial()) or (not team_only))) or   -- If someone alive talks (and not a special role in teamchat's case)
+	(sTeam and lTeam) then   -- If the speaker and listener are spectators
+	   return true 
+	end
+	
+	return false
+end
+
+local mumbles = {"mumble", "mm", "hmm", "hum", "mum", "mbm", "mble", "ham", "mammaries", "political situation", "mrmm", "hrm", 
+"uzbekistan", "mumu", "cheese export", "hmhm", "mmh", "mumble", "mphrrt", "mrh", "hmm", "mumble", "mbmm", "hmml", "mfrrm"}
 
 -- While a round is active, spectators can only talk among themselves. When they
 -- try to speak to all players they could divulge information about who killed
 -- them. So we mumblify them. In detective mode, we shut them up entirely.
 function GM:PlayerSay(ply, text, team_only)
-   if not IsValid(ply) then return end
-
-   if team_only and ply:Team() != TEAM_SPEC and GetRoundState() == ROUND_ACTIVE then
-      if ply:IsSpecial() then
-         -- traitor chat handling
-         RoleChatMsg(ply, ply:GetRole(), text)
-      else
-         LANG.Msg(ply, "inno_globalchat_hint")
-      end
-
-      return ""
-   end
-
-   if (not team_only) and GetRoundState() == ROUND_ACTIVE and ply:Team() == TEAM_SPEC then
-      if DetectiveMode() then
-         LANG.Msg(ply, "spec_teamchat_hint")
-         return ""
-      end
-
-      if not GetConVar("ttt_limit_spectator_chat"):GetBool() then
-         return text
-      end
-
-      local filtered = {}
-      for k, v in pairs(string.Explode(" ", text)) do
-         -- grab word characters and whitelisted interpunction
-         -- necessary or leetspeek will be used (by trolls especially)
-         local word, interp = string.match(v, "(%a*)([%.,;!%?]*)")
-         if word != "" then
-            table.insert(filtered, mumbles[math.random(1, #mumbles)] .. interp)
+   if not IsValid(ply) then return "" end
+	
+   if GetRoundState() == ROUND_ACTIVE then
+      local team = ply:Team() == TEAM_SPEC
+      if team and not DetectiveMode() then
+         local filtered = {}
+         for k, v in pairs(string.Explode(" ", text)) do
+            -- grab word characters and whitelisted interpunction
+            -- necessary or leetspeek will be used (by trolls especially)
+            local word, interp = string.match(v, "(%a*)([%.,;!%?]*)")
+            if word != "" then
+               table.insert(filtered, mumbles[math.random(1, #mumbles)] .. interp)
+            end
          end
-      end
 
-      -- make sure we have something to say
-      if table.Count(filtered) < 1 then
-         table.insert(filtered, mumbles[math.random(1, #mumbles)])
-      end
+         -- make sure we have something to say
+         if table.Count(filtered) < 1 then
+            table.insert(filtered, mumbles[math.random(1, #mumbles)])
+         end
 
-      table.insert( filtered, 1, "[MUMBLED]")
-      return table.concat(filtered, " ")
+         table.insert(filtered, 1, "[MUMBLED]")
+         return table.concat(filtered, " ")
+      elseif team_only and not team and ply:IsSpecial() then
+	     RoleChatMsg(ply, ply:GetRole(), text)
+		 return ""
+      end
    end
-
+   
    return text
 end
 
@@ -154,7 +162,7 @@ end
 local loc_voice = CreateConVar("ttt_locational_voice", "0")
 
 -- Of course voice has to be limited as well
-function GM:PlayerCanHearPlayersVoice( listener, speaker )
+function GM:PlayerCanHearPlayersVoice(listener, speaker)
    -- Enforced silence
    if mute_all then
       return false, false

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
@@ -144,10 +144,6 @@ L.radio_button_steps   = "Footsteps"
 -- Intro screen shown after joining
 L.intro_help     = "If you're new to the game, press F1 for instructions!"
 
--- Chat-related
-L.spec_teamchat_hint = "HINT: As spectator, use team chat to talk during an active round!"
-L.inno_globalchat_hint = "When innocent, use global chat to communicate."
-
 -- "Continue playing" vote
 L.contvote_continue = "Continue playing this"
 L.contvote_change   = "Start a vote"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/german.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/german.lua
@@ -144,10 +144,6 @@ L.radio_button_steps   = "Schritte"
 -- Intro screen shown after joining
 L.intro_help     = "Wenn du zum ersten Mal spielst, dann drücke F1 für Instruktionen!"
 
--- Chat-related
-L.spec_teamchat_hint = "TIPP: Als Zuschauer den Teamchat benutzen um in einer aktiven Runde zu chatten!"
-L.inno_globalchat_hint = "Wenn unschuldig, nutze den globalen Chat um zu kommunizieren."
-
 -- "Continue playing" vote
 L.contvote_continue = "Weiterspielen"
 L.contvote_change   = "Abstimmung starten"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/portuguese.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/portuguese.lua
@@ -145,10 +145,6 @@ L.radio_button_steps   = "Passos"
 -- Intro screen shown after joining
 L.intro_help     = "Se você é novato, aperte F1 para instruções!"
 
--- Chat-related
-L.spec_teamchat_hint = "DICA: Como espectador, use o chat de time para conversar durante uma rodada que não acabou!"
-L.inno_globalchat_hint = "Quando inocente, use o chat global para comunicar-se."
-
 -- "Continue playing" vote
 L.contvote_continue = "Continuar jogando isso"
 L.contvote_change   = "Começar votação"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/russian.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/russian.lua
@@ -144,10 +144,6 @@ L.radio_button_steps   = "Шаги"
 -- Intro screen shown after joining
 L.intro_help     = "Если вы новичок, нажмите F1 для помощи!"
 
--- Chat-related
-L.spec_teamchat_hint = "ПОДСКАЗКА: За наблюдателя вы можете говорить только в TEAM чат!"
-L.inno_globalchat_hint = "Если вы невиновны, используйте глобальный чат для разговора."
-
 -- "Continue playing" vote
 L.contvote_continue = "Продолжить игру на этой"
 L.contvote_change   = "Начать голосование"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/spanish.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/spanish.lua
@@ -144,10 +144,6 @@ L.radio_button_steps   = "Pasos"
 -- Intro screen shown after joining
 L.intro_help     = "¡Si eres nuevo en el juego pulsa F1 para ver las instrucciones!"
 
--- Chat-related
-L.spec_teamchat_hint = "CONSEJO: ¡Como espectador, usa el chat de equipo para hablar durante una ronda!"
-L.inno_globalchat_hint = "Cuando eres inocente, usa el chat global para comunicarte."
-
 -- "Continue playing" vote
 L.contvote_continue = "Seguir jugando este"
 L.contvote_change   = "Iniciar una votación"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/swedish.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/swedish.lua
@@ -145,10 +145,6 @@ L.radio_button_steps   = "Fotsteg"
 -- Intro screen shown after joining
 L.intro_help     = "Om du är ny till detta spel, tryck F1 för att få instruktioner!"
 
--- Chat-related
-L.spec_teamchat_hint = "TIPS: Som åskådare, använd team-chatten för att prata under en pågående runda!"
-L.inno_globalchat_hint = "Om du är oskyldig, använd den globala chatten för att kommunicera."
-
 -- "Continue playing" vote
 L.contvote_continue = "Fortsätt att spela denna"
 L.contvote_change   = "Påbörja en omröstning"

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/tradchinese.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/tradchinese.lua
@@ -144,10 +144,6 @@ L.radio_button_steps   = "腳步聲 "
 -- Intro screen shown after joining
 L.intro_help     = "若你是遊戲初學者，可按下F1查看遊戲教學！ "
 
--- Chat-related
-L.spec_teamchat_hint = "提示：身為旁觀者，遊戲進行中只能使用團隊對話。 "
-L.inno_globalchat_hint = "身為無辜者，可使用全體對話（y）來交流。 "
-
 -- "Continue playing" vote
 L.contvote_continue = "繼續進行遊戲 "
 L.contvote_change   = "發起投票 "


### PR DESCRIPTION
No more shitty redirects, no more tag ghosting. Uses a series of checks in PlayerCanSeePlayersChat (thanks Robot) to direct who can view chat. Tested extensively for the past two days with multiple people.