### PR TITLE
Consistency for number of return values

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,8 +1,8 @@
-local gmod                        = gmod
-local pairs                        = pairs
-local isfunction        = isfunction
-local isstring                = isstring
-local IsValid                = IsValid
+local gmo			= gmod
+local pair			= pairs
+local isfunction		= isfunction
+local isstrin			= isstring
+local IsVali			= IsValid
 
 module( "hook" )
 
@@ -72,7 +72,7 @@ function Call( name, gm, ... )
 	local HookTable = Hooks[ name ]
 	if ( HookTable != nil ) then
 	
-		local a, b, c, d, e, f;
+		local a = {};
 
 		for k, v in pairs( HookTable ) do 
 			
@@ -81,7 +81,7 @@ function Call( name, gm, ... )
 				--
 				-- If it's a string, it's cool
 				--
-				a, b, c, d, e, f = v( ... )
+				a = { v( ... ) }
 
 			else
 
@@ -93,7 +93,7 @@ function Call( name, gm, ... )
 					--
 					-- If the object is valid - pass it as the first argument (self)
 					--
-					a, b, c, d, e, f = v( k, ... )
+					a = { v( ... ) }
 				else
 					--
 					-- If the object has become invalid - remove it
@@ -105,8 +105,8 @@ function Call( name, gm, ... )
 			--
 			-- Hook returned a value - it overrides the gamemode function
 			--
-			if ( a != nil ) then
-				return a, b, c, d, e, f
+			if ( a[1] != nil ) then
+				return unpack( a )
 			end
 				
 		end

--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,4 +1,4 @@
-local gmo			= gmod
+local gmod			= gmod
 local pair			= pairs
 local isfunction		= isfunction
 local isstrin			= isstring

--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -3,6 +3,7 @@ local pairs			= pairs
 local isfunction		= isfunction
 local isstring			= isstring
 local IsValid			= IsValid
+local unpack			= unpack
 
 module( "hook" )
 

--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,7 +1,7 @@
 local gmod			= gmod
 local pairs			= pairs
 local isfunction		= isfunction
-local isstrind			= isstring
+local isstring			= isstring
 local IsValid			= IsValid
 
 module( "hook" )

--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,8 +1,8 @@
 local gmod			= gmod
-local pair			= pairs
+local pairs			= pairs
 local isfunction		= isfunction
-local isstrin			= isstring
-local IsVali			= IsValid
+local isstrind			= isstring
+local IsValid			= IsValid
 
 module( "hook" )
 

--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -93,7 +93,7 @@ function Call( name, gm, ... )
 					--
 					-- If the object is valid - pass it as the first argument (self)
 					--
-					a = { v( ... ) }
+					a = { v( k, ... ) }
 				else
 					--
 					-- If the object has become invalid - remove it


### PR DESCRIPTION
Gamemode hooks can return any number of values where as hooks created through hook.Add() could only return at most 6. This pull creates consistency between the two by allowing hooks created through hook.Add() to also return any number of values.