### PR TITLE
Addon compatibility

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -97,7 +97,7 @@ end
 -----------------------------------------------------------]]
 function GM:PlayerSay( player, text, teamonly )
 
-	return text
+	return text or ""
 
 end
 


### PR DESCRIPTION
After the recent update returning nil on a player say hook will cause the following error :"Error: hook->PlayerSay returned a non-string!".

Many addons return nil during their hooks.  

This will stop those errors.