### PR TITLE
TTT: Disable weapon picking up

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -54,7 +54,7 @@ local pin_rag_inno = CreateConVar("ttt_ragdoll_pinning_innocents", "0")
 -- Allowing weapon pickups can allow players to cause a crash in the physics
 -- system (ie. not fixable). Tuning the range seems to make this more
 -- difficult. Not sure why. It's that kind of crash.
-local allow_wep = CreateConVar("ttt_weapon_carrying", "1")
+local allow_wep = CreateConVar("ttt_weapon_carrying", "0")
 local wep_range = CreateConVar("ttt_weapon_carrying_range", "50")
 
 -- not customizable via convars as some objects rely on not being carryable for


### PR DESCRIPTION
This crash has been in TTT forever and now it's being widely abused. Until the magneto stick is entirely redone or the cause of the crashes are found, this should be disabled by default