### PR TITLE
Fix backwards bunnyhopping

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
@@ -189,7 +189,7 @@ function PLAYER:FinishMove( move )
 		end
 		
 		-- Reverse it if the player is running backwards
-		if move:GetForwardSpeed() < 0 then
+		if move:GetVelocity():Dot(forward) < 0 then
 			speedAddition = -speedAddition
 		end
 		


### PR DESCRIPTION
Since move:GetForwardSpeed() returns 0 when the player isn't pushing any keys, but move:GetVelocity() returns the actual speed.