### PR TITLE
Make light and lamp entities editable

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
@@ -4,6 +4,7 @@ DEFINE_BASECLASS( "base_gmodentity" )
 
 ENT.Spawnable			= false
 ENT.RenderGroup 		= RENDERGROUP_BOTH
+ENT.Editable			= true
 
 local matLight 		= Material( "sprites/light_ignorez" )
 local MODEL			= Model( "models/MaxOfS2D/light_tubular.mdl" )
@@ -13,13 +14,19 @@ local MODEL			= Model( "models/MaxOfS2D/light_tubular.mdl" )
 --
 function ENT:SetupDataTables()
 
-	self:NetworkVar( "Bool", 0, "On" );
-	self:NetworkVar( "Bool", 1, "Toggle" );
-	self:NetworkVar( "Float", 1, "LightSize" );
-	self:NetworkVar( "Float", 2, "Brightness" );
-
+	self:NetworkVar( "Bool",	0, "On", 		{ KeyName = "on", 			Edit = { type = "Boolean", 		order = 1 } }  );
+	self:NetworkVar( "Bool", 	1, "Toggle" );
+	self:NetworkVar( "Float",	0, "LightSize", 	{ KeyName = "lightsize", 		Edit = { type = "Float", 		order = 2, min = 0, max = 1024 } }  );
+	self:NetworkVar( "Float",	1, "Brightness", 	{ KeyName = "brightness", 		Edit = { type = "Float", 		order = 3, min = 0, max = 10 } }  );
+	self:NetworkVar( "Vector",	0, "LightColor", 	{ KeyName = "lightcol", 		Edit = { type = "VectorColor", 	order = 4 } }  );
+	
+	self:NetworkVarNotify( "LightColor",	self.OnColorChanged );
+	
 end
 
+function ENT:OnColorChanged(var,old,new)
+	self:SetColor(new:ToColor())
+end
 
 function ENT:Initialize()
 

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
@@ -16,7 +16,7 @@ function ENT:SetupDataTables()
 
 	self:NetworkVar( "Bool",	0, "On", 		{ KeyName = "on", 			Edit = { type = "Boolean", 		order = 1 } }  );
 	self:NetworkVar( "Bool", 	1, "Toggle" );
-	self:NetworkVar( "Float",	0, "LightSize", 	{ KeyName = "lightsize", 		Edit = { type = "Float", 		order = 2, min = 0, max = 1024 } }  );
+	self:NetworkVar( "Float",	0, "Radius", 		{ KeyName = "lightsize", 		Edit = { type = "Float", 		order = 2, min = 0, max = 1024 } }  );
 	self:NetworkVar( "Float",	1, "Brightness", 	{ KeyName = "brightness", 		Edit = { type = "Float", 		order = 3, min = 0, max = 10 } }  );
 	self:NetworkVar( "Vector",	0, "LightColor", 	{ KeyName = "lightcol", 		Edit = { type = "VectorColor", 	order = 4 } }  );
 	
@@ -85,8 +85,8 @@ function ENT:Think()
 			dlight.g = c.g
 			dlight.b = c.b
 			dlight.Brightness = self:GetBrightness()
-			dlight.Decay = self:GetLightSize() * 5
-			dlight.Size = self:GetLightSize()
+			dlight.Decay = self:GetRadius() * 5
+			dlight.Size = self:GetRadius()
 			dlight.DieTime = CurTime() + 1
 
 		end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
@@ -39,9 +39,9 @@ function TOOL:LeftClick( trace )
 
 	if	( IsValid( trace.Entity ) && trace.Entity:GetClass() == "gmod_lamp" && trace.Entity:GetPlayer() == ply ) then
 	
-		trace.Entity:SetColor( Color( r, g, b, 255 ) )
+		trace.Entity:SetLightColor( Vector( r, g, b )/255 )
 		trace.Entity:SetFlashlightTexture( texture )
-		trace.Entity:SetLightFOV( fov )
+		trace.Entity:SetFOV( fov )
 		trace.Entity:SetDistance( distance )
 		trace.Entity:SetBrightness( bright )
 		trace.Entity:SetToggle( !toggle )
@@ -126,12 +126,16 @@ if ( SERVER ) then
 
 		lamp:SetModel( Model )
 		lamp:SetFlashlightTexture( Texture )
-		lamp:SetLightFOV( fov )
-		lamp:SetColor( Color( r, g, b, 255 ) )
+		lamp:SetFOV( fov )
+		lamp:SetLightColor( Vector( r, g, b )/255 )
 		lamp:SetDistance( distance )
 		lamp:SetBrightness( brightness )
-		lamp:Switch( on )
 		lamp:SetToggle( !toggle )
+		if !toggle then
+			lamp:Switch( on )
+		else
+			lamp:Switch( off )
+		end
 
 		duplicator.DoGeneric( lamp, Data )
 	

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
@@ -44,7 +44,7 @@ function TOOL:LeftClick( trace, attach )
 	
 	if	( IsValid( trace.Entity ) && trace.Entity:GetClass() == "gmod_light" && trace.Entity:GetPlayer() == ply ) then
 
-		trace.Entity:SetColor( Color( r, g, b, 255 ) )
+		trace.Entity:SetLightColor( Vector( r, g, b )/255 )
 		trace.Entity.r = r
 		trace.Entity.g = g
 		trace.Entity.b = b
@@ -128,7 +128,7 @@ if ( SERVER ) then
 		
 		duplicator.DoGeneric( lamp, Data )
 
-		lamp:SetColor( Color( r, g, b, 255 ) )
+		lamp:SetLightColor( Vector( r, g, b )/255 )
 		lamp:SetBrightness( brght )
 		lamp:SetLightSize( size )
 		lamp:SetToggle( !toggle )

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
@@ -52,7 +52,7 @@ function TOOL:LeftClick( trace, attach )
 		trace.Entity.Size = size
 		
 		trace.Entity:SetBrightness( brght )
-		trace.Entity:SetLightSize( size )
+		trace.Entity:SetRadius( size )
 		trace.Entity:SetToggle( !toggle )
 		
 		trace.Entity.KeyDown = key
@@ -130,7 +130,7 @@ if ( SERVER ) then
 
 		lamp:SetLightColor( Vector( r, g, b )/255 )
 		lamp:SetBrightness( brght )
-		lamp:SetLightSize( size )
+		lamp:SetRadius( size )
 		lamp:SetToggle( !toggle )
 		lamp:SetOn( on )
 


### PR DESCRIPTION
This allows the light and lamp entities to be edited from the context menu, allowing for users to change its properties and see the results in real time