### PR TITLE
TTT: Reverted default detective values

### DIFF
--- a/garrysmod/gamemodes/terrortown/terrortown.txt
+++ b/garrysmod/gamemodes/terrortown/terrortown.txt
@@ -132,7 +132,7 @@
 			"name"		"ttt_detective_pct"
 			"text"		"Detective Ratio"
 			"type"		"Numeric"
-			"default"	"0.13"
+			"default"	"0.125"
 		}
 		
 		19
@@ -148,7 +148,7 @@
 			"name"		"ttt_detective_min_players"
 			"text"		"Min Detective Playercount"
 			"type"		"Numeric"
-			"default"	"10"
+			"default"	"8"
 		}
 		
 		21


### PR DESCRIPTION
https://github.com/garrynewman/garrysmod/blob/master/garrysmod/gamemodes/terrortown/gamemode/init.lua#L76

This is why people were experiencing lower detective numbers since last update. Also, changed the percent value to .125 since that's actually 1/8.