### PR TITLE
Improve map filtering display

### DIFF
--- a/garrysmod/html/template/newgame.html
+++ b/garrysmod/html/template/newgame.html
@@ -5,7 +5,7 @@
 			<div class="controls">
 				
 				<ul>
-					<li class="noisy category {{IfElse( category.category == CurrentCategory, 'active', '' )}}" ng-repeat="category in MapList | orderBy:'order'" ng-hide="category.maps.length == 0" ng-click="SwitchCategory(category.category)">
+					<li class="noisy category {{IfElse( category.category == CurrentCategory, 'active', '' )}}" ng-repeat="category in MapList | orderBy:'order'" ng-hide="CountFiltered(category.maps) == 0" ng-click="SwitchCategory(category.category)">
 						<div class='name'>{{category.category}}</div>
 						<div class='count'>{{CountFiltered(category.maps)}}</div>
 					</li>


### PR DESCRIPTION
Currently when searching for a map (singleplayer) it shows all the categories and it can be hard to see which ones have matches.

This change makes it only show categories with matches: https://puu.sh/iAONC/119f84b5a4.jpg