### PR TITLE
TTT: Removed all traces of teamchat/globalchat hints

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -321,8 +321,6 @@ local styledmessages = {
    },
 
    chat_plain = {
-      "spec_teamchat_hint",
-      "inno_globalchat_hint",
       "body_call",
       "disg_turned_on",
       "disg_turned_off"


### PR DESCRIPTION
TTT likes to call cl_lang instead of the actual lang file for language strings in some cases. This will get rid of the removed language strings for good.