### PR TITLE
DCollapsibleCategory fixes

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -1,7 +1,7 @@
 --
 --  ___  ___   _   _   _    __   _   ___ ___ __ __
 -- |_ _|| __| / \ | \_/ |  / _| / \ | o \ o \\ V /
---  | | | _| | o || \_/ | ( |_n| o ||   /   / \ / 
+--  | | | _| | o || \_/ | ( |_n| o ||   /   / \ /
 --  |_| |___||_n_||_| |_|  \__/|_n_||_|\\_|\\ |_|  2012
 --
 --
@@ -344,21 +344,21 @@ end
 function SKIN:PaintFrame( panel, w, h )
 
 	if ( panel.m_bPaintShadow ) then
-	
+
 		DisableClipping( true )
 		SKIN.tex.Shadow( -4, -4, w+10, h+10 )
 		DisableClipping( false )
-	
+
 	end
-	
+
 	if ( panel:HasHierarchicalFocus() ) then
-	
+
 		self.tex.Window.Normal( 0, 0, w, h )
-	
+
 	else
-	
+
 		self.tex.Window.Inactive( 0, 0, w, h )
-	
+
 	end
 
 end
@@ -369,19 +369,19 @@ end
 function SKIN:PaintButton( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel.Depressed || panel:IsSelected() || panel:GetToggle() ) then
 		return self.tex.Button_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Button_Dead( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Button_Hovered( 0, 0, w, h )
 	end
-	
+
 	self.tex.Button( 0, 0, w, h )
 
 end
@@ -393,7 +393,7 @@ end
 function SKIN:PaintTree( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	self.tex.Tree( 0, 0, w, h, panel.m_bgColor )
 
 end
@@ -405,21 +405,21 @@ end
 function SKIN:PaintCheckBox( panel, w, h )
 
 	if ( panel:GetChecked() ) then
-	
+
 		if ( panel:GetDisabled() ) then
 			self.tex.CheckboxD_Checked( 0, 0, w, h )
 		else
 			self.tex.Checkbox_Checked( 0, 0, w, h )
 		end
-		
+
 	else
-	
+
 		if ( panel:GetDisabled() ) then
 			self.tex.CheckboxD( 0, 0, w, h )
 		else
 			self.tex.Checkbox( 0, 0, w, h )
 		end
-	
+
 	end
 
 end
@@ -429,9 +429,9 @@ end
 -----------------------------------------------------------]]
 function SKIN:PaintExpandButton( panel, w, h )
 
-	if ( !panel:GetExpanded() ) then 
+	if ( !panel:GetExpanded() ) then
 		self.tex.TreePlus( 0, 0, w, h )
-	else 
+	else
 		self.tex.TreeMinus( 0, 0, w, h )
 	end
 
@@ -443,7 +443,7 @@ end
 function SKIN:PaintTextEntry( panel, w, h )
 
 	if ( panel.m_bBackground ) then
-	
+
 		if ( panel:GetDisabled() ) then
 			self.tex.TextBox_Disabled( 0, 0, w, h )
 		elseif ( panel:HasFocus() ) then
@@ -451,7 +451,7 @@ function SKIN:PaintTextEntry( panel, w, h )
 		else
 			self.tex.TextBox( 0, 0, w, h )
 		end
-	
+
 	end
 
 
@@ -489,7 +489,7 @@ function SKIN:PaintMenuOption( panel, w, h )
 	if ( panel.m_bBackground && (panel.Hovered || panel.Highlight) ) then
 		self.tex.MenuBG_Hover( 0, 0, w, h )
 	end
-	
+
 	if ( panel:GetChecked() ) then
 		self.tex.Menu_Check( 5, h/2-7, 15, 15 )
 	end
@@ -515,7 +515,7 @@ function SKIN:PaintPropertySheet( panel, w, h )
 	local ActiveTab = panel:GetActiveTab()
 	local Offset = 0
 	if ( ActiveTab ) then Offset = ActiveTab:GetTall()-8 end
-	
+
 	self.tex.Tab_Control( 0, Offset, w, h-Offset )
 
 end
@@ -528,7 +528,7 @@ function SKIN:PaintTab( panel, w, h )
 	if ( panel:GetPropertySheet():GetActiveTab() == panel ) then
 		return self:PaintActiveTab( panel, w, h )
 	end
-	
+
 	self.tex.TabT_Inactive( 0, 0, w, h )
 
 end
@@ -545,19 +545,19 @@ end
 function SKIN:PaintWindowCloseButton( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Window.Close( 0, 0, w, h, Color( 255, 255, 255, 50 ) )
 	end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Window.Close_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Window.Close_Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Window.Close( 0, 0, w, h )
 
 end
@@ -565,15 +565,15 @@ end
 function SKIN:PaintWindowMinimizeButton( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Window.Mini( 0, 0, w, h, Color( 255, 255, 255, 50 ) )
 	end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Window.Mini_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Window.Mini_Hover( 0, 0, w, h )
 	end
@@ -585,15 +585,15 @@ end
 function SKIN:PaintWindowMaximizeButton( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Window.Maxi( 0, 0, w, h, Color( 255, 255, 255, 50 ) )
 	end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Window.Maxi_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Window.Maxi_Hover( 0, 0, w, h )
 	end
@@ -619,15 +619,15 @@ function SKIN:PaintScrollBarGrip( panel, w, h )
 	if ( panel:GetDisabled() ) then
 		return self.tex.Scroller.ButtonV_Disabled( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Depressed ) then
 		return self.tex.Scroller.ButtonV_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Scroller.ButtonV_Hover( 0, 0, w, h )
 	end
-	
+
 	return self.tex.Scroller.ButtonV_Normal( 0, 0, w, h )
 
 end
@@ -638,19 +638,19 @@ end
 function SKIN:PaintButtonDown( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Scroller.DownButton_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Scroller.DownButton_Dead( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Scroller.DownButton_Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Scroller.DownButton_Normal( 0, 0, w, h )
 
 end
@@ -661,19 +661,19 @@ end
 function SKIN:PaintButtonUp( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Scroller.UpButton_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Scroller.UpButton_Dead( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Scroller.UpButton_Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Scroller.UpButton_Normal( 0, 0, w, h )
 
 end
@@ -707,19 +707,19 @@ end
 function SKIN:PaintButtonRight( panel, w, h )
 
 	if ( !panel.m_bBackground ) then return end
-	
+
 	if ( panel.Depressed || panel:IsSelected() ) then
 		return self.tex.Scroller.RightButton_Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Scroller.RightButton_Dead( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Scroller.RightButton_Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Scroller.RightButton_Normal( 0, 0, w, h )
 
 end
@@ -733,15 +733,15 @@ function SKIN:PaintComboDownArrow( panel, w, h )
 	if ( panel.ComboBox:GetDisabled() ) then
 		return self.tex.Input.ComboBox.Button.Disabled( 0, 0, w, h )
 	end
-	
+
 	if ( panel.ComboBox.Depressed || panel.ComboBox:IsMenuOpen() ) then
 		return self.tex.Input.ComboBox.Button.Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.ComboBox.Hovered ) then
 		return self.tex.Input.ComboBox.Button.Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Input.ComboBox.Button.Normal( 0, 0, w, h )
 
 end
@@ -750,19 +750,19 @@ end
 	ComboBox
 -----------------------------------------------------------]]
 function SKIN:PaintComboBox( panel, w, h )
-	
+
 	if ( panel:GetDisabled() ) then
 		return self.tex.Input.ComboBox.Disabled( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Depressed || panel:IsMenuOpen() ) then
 		return self.tex.Input.ComboBox.Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Input.ComboBox.Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Input.ComboBox.Normal( 0, 0, w, h )
 
 end
@@ -784,15 +784,15 @@ function SKIN:PaintNumberUp( panel, w, h )
 	if ( panel:GetDisabled() ) then
 		return self.tex.Input.UpDown.Up.Disabled( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Depressed ) then
 		return self.tex.Input.UpDown.Up.Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Input.UpDown.Up.Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Input.UpDown.Up.Normal( 0, 0, w, h )
 
 end
@@ -805,15 +805,15 @@ function SKIN:PaintNumberDown( panel, w, h )
 	if ( panel:GetDisabled() ) then
 		return self.tex.Input.UpDown.Down.Disabled( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Depressed ) then
 		return self.tex.Input.UpDown.Down.Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Input.UpDown.Down.Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Input.UpDown.Down.Normal( 0, 0, w, h )
 
 end
@@ -821,14 +821,14 @@ end
 function SKIN:PaintTreeNode( panel, w, h )
 
 	if ( !panel.m_bDrawLines ) then return end
-	
+
 	surface.SetDrawColor( self.Colours.Tree.Lines )
-	
+
 	if ( panel.m_bLastChild ) then
-	
+
 		surface.DrawRect( 9, 0, 1, 7 )
 		surface.DrawRect( 9, 7, 9, 1 )
-	
+
 	else
 		surface.DrawRect( 9, 0, 1, h )
 		surface.DrawRect( 9, 7, 9, 1 )
@@ -840,11 +840,11 @@ end
 function SKIN:PaintTreeNodeButton( panel, w, h )
 
 	if ( !panel.m_bSelected ) then return end
-	
+
 	-- Don't worry this isn't working out the size every render
 	-- it just gets the cached value from inside the Label
-	local w, _ = panel:GetTextSize() 
-	
+	local w, _ = panel:GetTextSize()
+
 	self.tex.Selection( 38, 0, w + 6, h )
 
 end
@@ -858,15 +858,15 @@ end
 function SKIN:PaintSliderKnob( panel, w, h )
 
 	if ( panel:GetDisabled() ) then	return self.tex.Input.Slider.H.Disabled( 0, 0, w, h ) end
-	
+
 	if ( panel.Depressed ) then
 		return self.tex.Input.Slider.H.Down( 0, 0, w, h )
 	end
-	
+
 	if ( panel.Hovered ) then
 		return self.tex.Input.Slider.H.Hover( 0, 0, w, h )
 	end
-	
+
 	self.tex.Input.Slider.H.Normal( 0, 0, w, h )
 
 end
@@ -876,11 +876,11 @@ local function PaintNotches( x, y, w, h, num )
 	if ( !num ) then return end
 
 	local space = w / num
-	
+
 	for i=0, num do
-	
+
 		surface.DrawRect( x + i * space, y + 4, 1,  5 )
-	
+
 	end
 
 end
@@ -889,7 +889,7 @@ function SKIN:PaintNumSlider( panel, w, h )
 
 	surface.SetDrawColor( Color( 0, 0, 0, 100 ) )
 	surface.DrawRect( 8, h / 2 - 1, w - 15, 1 )
-	
+
 	PaintNotches( 8, h / 2 - 1, w - 16, 1, panel.m_iNotches )
 
 end
@@ -906,8 +906,8 @@ function SKIN:PaintCollapsibleCategory( panel, w, h )
 	if ( !panel:GetExpanded() && h < 40 ) then
 		return self.tex.CategoryList.Header( 0, 0, w, h )
 	end
-	
-	self.tex.CategoryList.Inner( 0, 0, w, h )
+
+	self.tex.CategoryList.Inner( 0, 0, w, 63 )
 
 end
 
@@ -924,13 +924,13 @@ function SKIN:PaintCategoryButton( panel, w, h )
 		if ( panel.Depressed || panel.m_bSelected ) then surface.SetDrawColor( self.Colours.Category.LineAlt.Button_Selected )
 		elseif ( panel.Hovered ) then surface.SetDrawColor( self.Colours.Category.LineAlt.Button_Hover )
 		else surface.SetDrawColor( self.Colours.Category.LineAlt.Button ) end
-	
+
 	else
-	
+
 		if ( panel.Depressed || panel.m_bSelected ) then surface.SetDrawColor( self.Colours.Category.Line.Button_Selected )
 		elseif ( panel.Hovered ) then surface.SetDrawColor( self.Colours.Category.Line.Button_Hover )
 		else surface.SetDrawColor( self.Colours.Category.Line.Button ) end
-		
+
 	end
 
 	surface.DrawRect( 0, 0, w, h )
@@ -942,15 +942,15 @@ function SKIN:PaintListViewLine( panel, w, h )
 	if ( panel:IsSelected() ) then
 
 		self.tex.Input.ListBox.EvenLineSelected( 0, 0, w, h )
-	 
+
 	elseif ( panel.Hovered ) then
 
 		self.tex.Input.ListBox.Hovered( 0, 0, w, h )
-	 
+
 	elseif ( panel.m_bAlt ) then
 
 		self.tex.Input.ListBox.EvenLine( 0, 0, w, h )
-	         
+
 	end
 
 end

--- a/garrysmod/lua/vgui/dcategorycollapse.lua
+++ b/garrysmod/lua/vgui/dcategorycollapse.lua
@@ -1,47 +1,47 @@
---[[   _                                
-	( )                               
-   _| |   __   _ __   ___ ___     _ _ 
+--[[   _
+	( )
+   _| |   __   _ __   ___ ___     _ _
  /'_` | /'__`\( '__)/' _ ` _ `\ /'_` )
 ( (_| |(  ___/| |   | ( ) ( ) |( (_| |
-`\__,_)`\____)(_)   (_) (_) (_)`\__,_) 
+`\__,_)`\____)(_)   (_) (_) (_)`\__,_)
 
-	DCategoryCollapse
+	DCollapsibleCategory
 
 --]]
 
-local PANEL = 
+local PANEL =
 {
 
 	Init = function( self )
-	
+
 		self:SetContentAlignment( 4 )
 		self:SetTextInset( 5, 0 )
 		self:SetFont( "DermaDefaultBold" )
-	
+
 	end,
-	
+
 	DoClick = function( self )
-	
+
 		self:GetParent():Toggle()
-	
+
 	end,
-	
+
 	UpdateColours = function( self, skin )
-	
+
 		if ( !self:GetParent():GetExpanded() ) then
-			self:SetExpensiveShadow( 0, Color( 0, 0, 0, 200 ) )	
-			return self:SetTextStyleColor( skin.Colours.Category.Header_Closed ) 
+			self:SetExpensiveShadow( 0, Color( 0, 0, 0, 200 ) )
+			return self:SetTextStyleColor( skin.Colours.Category.Header_Closed )
 		end
-		
+
 		self:SetExpensiveShadow( 1, Color( 0, 0, 0, 100 ) )
 		return self:SetTextStyleColor( skin.Colours.Category.Header )
-	
+
 	end,
-	
+
 	Paint = function( self )
-	
+
 		// Do nothing!
-	
+
 	end,
 
 	GenerateExample = function()
@@ -74,14 +74,14 @@ function PANEL:Init()
 	self.Header = vgui.Create( "DCategoryHeader", self )
 	self.Header:Dock( TOP )
 	self.Header:SetSize( 20, 20 )
-	
+
 	self:SetSize( 16, 16 );
 	self:SetExpanded( true )
 	self:SetMouseInputEnabled( true )
-	
+
 	self:SetAnimTime( 0.2 )
 	self.animSlide = Derma_Anim( "Anim", self, self.AnimSlide )
-	
+
 	self:SetPaintBackground( true )
 	self:DockMargin( 0, 0, 0, 2 )
 	self:DockPadding( 0, 0, 0, 5 )
@@ -96,45 +96,45 @@ function PANEL:Add( strName )
 	local button = vgui.Create( "DButton", self )
 	button.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "CategoryButton", panel, w, h ) end
 	button.UpdateColours = function( button, skin )
-	
+
 			if ( button.AltLine ) then
 
 				if ( button.Depressed || button.m_bSelected )		then return button:SetTextStyleColor( skin.Colours.Category.LineAlt.Text_Selected ) end
 				if ( hovered )										then return button:SetTextStyleColor( skin.Colours.Category.LineAlt.Text_Hover ) end
-				return button:SetTextStyleColor( skin.Colours.Category.LineAlt.Text )	
-						
+				return button:SetTextStyleColor( skin.Colours.Category.LineAlt.Text )
+
 			end
-	
+
 			if ( button.Depressed || button.m_bSelected )		then return button:SetTextStyleColor( skin.Colours.Category.Line.Text_Selected ) end
 			if ( hovered )										then return button:SetTextStyleColor( skin.Colours.Category.Line.Text_Hover ) end
 			return button:SetTextStyleColor( skin.Colours.Category.Line.Text )
-	
+
 		end
-		
+
 	button:SetHeight( 17 )
 	button:SetTextInset( 4, 0 )
-	
+
 	button:SetContentAlignment( 4 )
 	button:DockMargin( 1, 0, 1, 0 )
 	button.DoClickInternal =  function()
-	
+
 		if ( self:GetList() ) then
 			self:GetList():UnselectAll()
 		else
 			self:UnselectAll()
 		end
-		
+
 		button:SetSelected( true )
-		
+
 	end
-	
+
 	button:Dock( TOP )
 	button:SetText( strName )
-	
+
 	self:InvalidateLayout( true )
 	self:UpdateAltLines()
-	
-	return button 
+
+	return button
 
 end
 
@@ -142,11 +142,11 @@ function PANEL:UnselectAll()
 
 	local children = self:GetChildren()
 	for k, v in pairs( children ) do
-	
+
 		if ( v.SetSelected ) then
 			v:SetSelected( false )
 		end
-		
+
 	end
 
 end
@@ -155,7 +155,7 @@ function PANEL:UpdateAltLines()
 
 	local children = self:GetChildren()
 	for k, v in pairs( children ) do
-		v.AltLine = k % 2 != 1		
+		v.AltLine = k % 2 != 1
 	end
 
 end
@@ -197,7 +197,28 @@ function PANEL:SetContents( pContents )
 	self.Contents = pContents
 	self.Contents:SetParent( self )
 	self.Contents:Dock( FILL )
-	self:InvalidateLayout()
+	self:InvalidateLayout( true )
+
+	if ( !self:GetExpanded() ) then
+
+		self.OldHeight = self:GetTall()
+
+	end
+
+end
+
+--[[---------------------------------------------------------
+   Name: SetContents
+-----------------------------------------------------------]]
+function PANEL:SetExpanded( expanded )
+
+	self.m_bSizeExpanded = tobool( expanded )
+
+	if ( !self.m_bSizeExpanded ) then
+
+		self.OldHeight = self:GetTall()
+
+	end
 
 end
 
@@ -209,11 +230,11 @@ function PANEL:Toggle()
 	self:SetExpanded( !self:GetExpanded() )
 
 	self.animSlide:Start( self:GetAnimTime(), { From = self:GetTall() } )
-	
+
 	self:InvalidateLayout( true )
 	self:GetParent():InvalidateLayout()
 	self:GetParent():GetParent():InvalidateLayout()
-	
+
 	local cookie = '1'
 	if ( !self:GetExpanded() ) then cookie = '0' end
 	self:SetCookie( "Open", cookie )
@@ -238,7 +259,7 @@ function PANEL:DoExpansion( b )
 
 	if ( self.m_bSizeExpanded == b ) then return end
 	self:Toggle();
-	
+
 end
 
 --[[---------------------------------------------------------
@@ -249,29 +270,29 @@ function PANEL:PerformLayout()
 	local Padding = self:GetPadding() or 0
 
 	if ( self.Contents ) then
-		
+
 		if ( self:GetExpanded() ) then
 			self.Contents:InvalidateLayout( true )
 			self.Contents:SetVisible( true )
 		else
 			self.Contents:SetVisible( false )
 		end
-		
+
 	end
-	
+
 	if ( self:GetExpanded() ) then
 
 		self:SizeToChildren( false, true )
-	
+
 	else
-		
+
 		self:SetTall( self.Header:GetTall() )
-	
-	end	
-	
+
+	end
+
 	-- Make sure the color of header text is set
 	self.Header:ApplySchemeSettings()
-	
+
 	self.animSlide:Run()
 	self:UpdateAltLines();
 
@@ -283,7 +304,7 @@ end
 function PANEL:OnMousePressed( mcode )
 
 	if ( !self:GetParent().OnMousePressed ) then return end;
-	
+
 	return self:GetParent():OnMousePressed( mcode )
 
 end
@@ -292,18 +313,28 @@ end
    Name: AnimSlide
 -----------------------------------------------------------]]
 function PANEL:AnimSlide( anim, delta, data )
-	
+
 	self:InvalidateLayout()
 	self:InvalidateParent()
-	
+
 	if ( anim.Started ) then
-		data.To = self:GetTall()	
+
+		if ( self:GetExpanded() ) then
+
+			data.To = self.OldHeight
+
+		else
+
+			data.To = self:GetTall()
+
+		end
+
 	end
 
 	if ( self.Contents ) then self.Contents:SetVisible( true ) end
-	
+
 	self:SetTall( Lerp( delta, data.From, data.To ) )
-	
+
 end
 
 --[[---------------------------------------------------------
@@ -330,14 +361,14 @@ function PANEL:GenerateExample( ClassName, PropertySheet, Width, Height )
 		ctrl:SetLabel( "Category List Test Category" )
 		ctrl:SetSize( 300, 300 )
 		ctrl:SetPadding( 10 )
-		
+	
 		-- The contents can be any panel, even a DPanelList
 		local Contents = vgui.Create( "DButton" )
 		Contents:SetText( "This is the content of the control" )
 		ctrl:SetContents( Contents )
-		
+
 		ctrl:InvalidateLayout( true )
-		
+
 	PropertySheet:AddSheet( ClassName, ctrl, nil, true, true )
 
 end

--- a/garrysmod/lua/vgui/dcategorylist.lua
+++ b/garrysmod/lua/vgui/dcategorylist.lua
@@ -1,12 +1,12 @@
---[[   _                                
-	( )                               
-   _| |   __   _ __   ___ ___     _ _ 
+--[[   _
+	( )
+   _| |   __   _ __   ___ ___     _ _
  /'_` | /'__`\( '__)/' _ ` _ `\ /'_` )
 ( (_| |(  ___/| |   | ( ) ( ) |( (_| |
-`\__,_)`\____)(_)   (_) (_) (_)`\__,_) 
+`\__,_)`\____)(_)   (_) (_) (_)`\__,_)
 
 	DPanelList
-	
+
 	A window.
 
 --]]
@@ -29,7 +29,7 @@ function PANEL:AddItem( item )
 	item:Dock( TOP )
 	DScrollPanel.AddItem( self, item )
 	self:InvalidateLayout()
-	
+
 end
 
 --[[---------------------------------------------------------
@@ -40,10 +40,10 @@ function PANEL:Add( name )
 	local Category = vgui.Create( "DCollapsibleCategory", self )
 	Category:SetLabel( name )
 	Category:SetList( self )
-	
+
 	self:AddItem( Category )
-	
-	return Category	
+
+	return Category
 
 end
 
@@ -60,12 +60,34 @@ end
 function PANEL:UnselectAll()
 
 	for k, v in pairs( self:GetChildren() ) do
-	
+
 		if ( v.UnselectAll ) then
 			v:UnselectAll()
 		end
-	
+
 	end
+
+end
+
+function PANEL:GenerateExample( ClassName, PropertySheet, Width, Height )
+
+	local ctrl = vgui.Create( ClassName )
+		ctrl:SetSize( 300, 300 )
+
+		local Cat = ctrl:Add( "Test category with text contents" )
+		Cat:Add( "Item 1" )
+		Cat:Add( "Item 2" )
+
+		-- The contents can be any panel, even a DPanelList
+		local Cat2 = ctrl:Add( "Test category with panel contents" )
+		Cat2:SetTall( 100 )
+		local Contents = vgui.Create( "DButton" )
+		Contents:SetText( "This is the content of the category" )
+		Cat2:SetContents( Contents )
+
+		ctrl:InvalidateLayout( true )
+
+	PropertySheet:AddSheet( ClassName, ctrl, nil, true, true )
 
 end
 


### PR DESCRIPTION
* Fixed DCollapsibleCategory not expanding to correct height when using cat:SetContents.
* Fixed DCollapsibleCategory header height decreasing on animation (should have remained constant).
* Added DCategoryList example for the derma_controls concommand.
* Renamed dcategorycollapse.lua to dcollapsiblecategory.lua.
* Lowercased file names in vgui_base.lua.