### PR TITLE
TTT: Display inventory with fast weapon switching

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -30,7 +30,7 @@ function GM:PlayerBindPress(ply, bind, pressed)
       end
       return true
    elseif bind == "+attack" then
-      if WSWITCH.Show then
+      if WSWITCH:PreventAttack() then
          if not pressed then
             WSWITCH:ConfirmSelection()
          end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -225,7 +225,7 @@ function WSWITCH:DoSelect(idx)
 
    if self.cv.fast:GetBool() then
       -- immediately confirm if fastswitch is on
-      self:ConfirmSelection()
+      self:ConfirmSelection(true)
    end   
 end
 
@@ -283,15 +283,20 @@ function WSWITCH:Disable()
 end
 
 -- Switch to the currently selected weapon
-function WSWITCH:ConfirmSelection()
-   self:Disable()
+function WSWITCH:ConfirmSelection(noHide)
+   if not noHide then self:Disable() end
 
    for k, w in pairs(self.WeaponCache) do
       if k == self.Selected and IsValid(w) then
          RunConsoleCommand("wepswitch", w:GetClass())
          return
       end
-   end   
+   end
+end
+
+-- Allow for suppression of the attack command
+function WSWITCH:PreventAttack()
+   return self.Show and !self.cv.fast:GetBool()
 end
 
 function WSWITCH:Think()


### PR DESCRIPTION
Weapon switching is functionally identical, but at the added convenience of seeing your inventory at the same time.