### PR TITLE
Prevent weird model paths

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -8,6 +8,7 @@ include( "prop_tools.lua" )
 function CCSpawn( player, command, arguments )
 
 	if ( arguments[ 1 ] == nil ) then return end
+	if ( arguments[ 1 ]:find( "%.[/\\]" ) ) then return end
 	if ( !gamemode.Call( "PlayerSpawnObject", player, arguments[ 1 ], arguments[ 2 ] ) ) then return end
 	if ( !util.IsValidModel( arguments[ 1 ] ) ) then return end
 


### PR DESCRIPTION
Should stop gm_spawn from accepting weird paths like models/props_c17/lol/../oildrum001_explosive.mdl
Players can use this to bypass model blacklists that don't do this check.
