### PR TITLE
Typo in Primary Fire Sound

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -36,7 +36,7 @@ SWEP.ViewModelFOV		= 54
 SWEP.ViewModel          = Model("models/weapons/cstrike/c_snip_scout.mdl")
 SWEP.WorldModel         = Model("models/weapons/w_snip_scout.mdl")
 
-SWEP.Primary.Sound = Sound(")weapons/scout/scout_fire-1.wav")
+SWEP.Primary.Sound = Sound("weapons/scout/scout_fire-1.wav")
 
 SWEP.Secondary.Sound = Sound("Default.Zoom")
 


### PR DESCRIPTION
The real question is, why did the sound work in the first place and how was this silly typo never noticed?