### PR TITLE
Help prevent rigid rope from making crazy physics.

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
@@ -36,6 +36,11 @@ function TOOL:LeftClick( trace )
 		local width = self:GetClientNumber( "width" )
 		local rigid = self:GetClientNumber( "rigid" ) == 1
 		
+		--Should help prevent creating crazy physics
+		if rigid then
+			addlength = math.min( addlength, 100 )
+		end
+		
 		-- Get information we're about to use
 		local Ent1, Ent2 = self:GetEnt( 1 ), self:GetEnt( 2 )
 		local Bone1, Bone2 = self:GetBone( 1 ), self:GetBone( 2 )
@@ -93,6 +98,11 @@ function TOOL:RightClick( trace )
 		local material = self:GetClientInfo( "material" )
 		local width = self:GetClientNumber( "width" )
 		local rigid = self:GetClientNumber( "rigid" ) == 1
+		
+		--Should help prevent creating crazy physics
+		if rigid then
+			addlength = math.min( addlength, 100 )
+		end
 		
 		-- Get information we're about to use
 		local Ent1, Ent2 = self:GetEnt( 1 ), self:GetEnt( 2 )


### PR DESCRIPTION
I can't think of a reason why a rigid rope would need an add length, but I left it a little bit just in case.