### PR TITLE
Improve "weird model path" filtering.

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -8,7 +8,7 @@ include( "prop_tools.lua" )
 function CCSpawn( player, command, arguments )
 
 	if ( arguments[ 1 ] == nil ) then return end
-	if ( arguments[ 1 ]:find( "%.[/\\]" ) ) then return end
+	if ( arguments[ 1 ]:find( "[./\\][/\\]" ) ) then return end
 	if ( !gamemode.Call( "PlayerSpawnObject", player, arguments[ 1 ], arguments[ 2 ] ) ) then return end
 	if ( !util.IsValidModel( arguments[ 1 ] ) ) then return end
 


### PR DESCRIPTION
This improves #1020:
While a string such as `gm_spawn models/foo/../props_c17/furniturestove001a.mdl` gets blocked, this one still works: `gm_spawn models\/props_c17/furniturestove001a.mdl`.