### PR TITLE
TTT: Added 2 hooks for custom body search icons

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -220,6 +220,8 @@ function PreprocSearch(raw)
       end
    end
 
+   hook.Call("TTTBodySearchPopulate", nil, search, raw)
+
    return search
 end
 
@@ -485,6 +487,8 @@ local function ReceiveRagdollSearch()
    --
    local words = net.ReadString()
    search.words = (words ~= "") and words or nil
+   
+   hook.Call("TTTBodySearchEquipment", nil, search, eq)
 
    if search.show then
       ShowSearchScreen(search)


### PR DESCRIPTION
TTTBodySearchEquipment passes search (table containing search data right before processing), eq (integer with equipment bitflags) - use that to define custom fields in the search table.
TTTBodySearchPopulate passes search (PROCESSED table that will be displayed in the body search results), raw (unprocessed table - the one above)

Example:

	EQUIP_HELMET = 8

	table.insert(EquipmentItems[ROLE_DETECTIVE], {
		id       = EQUIP_HELMET,
		type     = "item_passive",
		material = "vgui/ttt/icon_helmet",
		name     = "Helmet",
		desc     = "Reduces any damage received to the\nhead by 50%."
	})

	hook.Add("TTTBodySearchEquipment", "body_eq_helmet", function(search, eq)
		search.eq_helmet = util.BitSet(eq, EQUIP_HELMET)
	end)

	hook.Add("TTTBodySearchPopulate", "body_eq_helmet_icon", function(search, raw)
		if (!raw.eq_helmet) then
			return end
	
		local highest = 0
		for _, v in pairs (search) do
			highest = math.max(highest, v.p)
		end

		search.eq_helmet = {img = "vgui/ttt/icon_helmet", text = "They had a helmet on.", p = highest + 1}
	end)

![4vglscl](https://cloud.githubusercontent.com/assets/1496804/9282560/873f7f5e-42cd-11e5-8eb2-2539d5c7365c.png)