### PR TITLE
Override duplicate names in AddAmmoType

### DIFF
--- a/garrysmod/lua/includes/extensions/game.lua
+++ b/garrysmod/lua/includes/extensions/game.lua
@@ -27,7 +27,7 @@ game.AddAmmoType = function ( tbl )
 	
 	for id, ammo in ipairs( AmmoTypes ) do
 		if ( tbl.name == ammo.name ) then
-			ammo = tbl
+			AmmoTypes[id] = tbl
 			return
 		end
 	end

--- a/garrysmod/lua/includes/extensions/game.lua
+++ b/garrysmod/lua/includes/extensions/game.lua
@@ -24,6 +24,13 @@ local AmmoTypes = {}
 game.AddAmmoType = function ( tbl )
 
 	if ( !tbl.name ) then return end
+	
+	for id, ammo in ipairs( AmmoTypes ) do
+		if ( tbl.name == ammo.name ) then
+			ammo = tbl
+			return
+		end
+	end
 
 	table.insert( AmmoTypes, tbl )
 


### PR DESCRIPTION
No more unpredictability of how the engine will choose which ammo table to use when BuildAmmoTypes is called. Now, only the last one will be sent
