### PR TITLE
TTT: Recheck collision rules after group reset

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -376,6 +376,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
 
    -- nonsolid to players, but can be picked up and shot
    rag:SetCollisionGroup(rag_collide:GetBool() and COLLISION_GROUP_WEAPON or COLLISION_GROUP_DEBRIS_TRIGGER)
+   timer.Simple( 1, rag.CollisionRulesChanged )
 
    -- flag this ragdoll as being a player's
    rag.player_ragdoll = true


### PR DESCRIPTION
After an immense amount of testing and reading source code, it seems that CollisionRulesChanged is already called internally by SetCollisionGroup, and then RecheckCollisionFilter is called on all of the children PhysObjects subsequently. Initially, calling CollisionRulesChanged immidiately after setting the collision group had no effect as expected, however, calling it in a timer seems to have settled any initial spasms.

Note that this is not a sure fix to all ragdoll related crashes; COLLISION_GROUP_DEBRIS_TRIGGER still seems to have some serious issues sending back collision data at high velocities/high collision rates, but this fix will at least cause less crashes to occur early on.