### PR TITLE
Add name change kick immunity for superadmins/admins and operators (ULX)

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -332,18 +332,20 @@ local function NameChangeKick()
 
    if GetRoundState() == ROUND_ACTIVE then
       for _, ply in pairs(player.GetHumans()) do
-         if ply.spawn_nick then
-            if ply.has_spawned and ply.spawn_nick != ply:Nick() then
-               local t = GetConVar("ttt_namechange_bantime"):GetInt()
-               local msg = "Changed name during a round"
-               if t > 0 then
-                  ply:KickBan(t, msg)
-               else
-                  ply:Kick(msg)
+         if not ply:IsAdmin() and not ply:IsUserGroup("operator") then
+            if ply.spawn_nick then
+               if ply.has_spawned and ply.spawn_nick != ply:Nick() then
+                  local t = GetConVar("ttt_namechange_bantime"):GetInt()
+                  local msg = "Changed name during a round"
+                  if t > 0 then
+                     ply:KickBan(t, msg)
+                  else
+                     ply:Kick(msg)
+                  end
                end
+            else
+               ply.spawn_nick = ply:Nick()
             end
-         else
-            ply.spawn_nick = ply:Nick()
          end
       end
    end


### PR DESCRIPTION
Admins of a server should have name change kick immunity.

First, because admins of a server should be trusted to not change their names during a round for an unfair advantage.

Second, it is useful for servers that require admins to wear a certain tag, in the case that an admin joins the server as a round starts, and realizes that he/she is not wearing the admin tag for that server.