### PR TITLE
Fixed utf8.codes to abide to Lua 5.3's implementation

### DIFF
--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -272,7 +272,9 @@ function Parse(ml, maxwidth)
 		blocks[i].text = string.gsub(blocks[i].text, "&gt;", ">")
 		blocks[i].text = string.gsub(blocks[i].text, "&lt;", "<")
 		blocks[i].text = string.gsub(blocks[i].text, "&amp;", "&")
-		for j, ch in utf8.codes( blocks[ i ].text ) do
+		for j, c in utf8.codes( blocks[ i ].text ) do
+
+			local ch = utf8.char( c )
 			
 			if (ch == "\n") then
 			


### PR DESCRIPTION
```lua
for x, y in utf8.codes( ... ) do
```

The `y` variable should be equal to the codepoint, not the byte sequence. This fixes that.