### PR TITLE
Clamped physgun color to above 0

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
@@ -105,8 +105,11 @@ function PLAYER:Spawn()
 	local col = self.Player:GetInfo( "cl_playercolor" )
 	self.Player:SetPlayerColor( Vector( col ) )
 
-	local col = self.Player:GetInfo( "cl_weaponcolor" )
-	self.Player:SetWeaponColor( Vector( col ) )
+	local col = Vector( self.Player:GetInfo( "cl_weaponcolor" ) )
+	if col:Length() == 0 then
+		col = Vector( 0.001, 0.001, 0.001 )
+	end
+	self.Player:SetWeaponColor( col )
 
 end
 


### PR DESCRIPTION
Fixes an exploit where beams would become invisible (minges use this). 
Alternative for legitimate uses:
![](http://i.imgur.com/IaXoWFV.png)