### PR TITLE
Fixed: DTileLayout spaceX/Y and border not being used.

### DIFF
--- a/garrysmod/lua/vgui/dtilelayout.lua
+++ b/garrysmod/lua/vgui/dtilelayout.lua
@@ -157,7 +157,7 @@ function PANEL:LayoutTiles()
 		
 		local x, y = self:FindFreeTile( 1, StartLine, w, h )
 		
-		v:SetPos( (x-1) * tilesize, (y-1) * tilesize )
+		v:SetPos( self:GetBorder() + (x-1) * (tilesize + self:GetSpaceX()), self:GetBorder() + (y-1) * (tilesize + self:GetSpaceY()) )
 		
 		self:ConsumeTiles( x, y, w, h )
 		


### PR DESCRIPTION
I noticed that called SetSpaceX, SetSpaceY and SetBorder of DTileLayout doesnt have an affect on the layout of children so I have created a fix for that.