### PR TITLE
Preventing right-click exploit with Hydraulic/Muscle/Slider/Winch tool

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
@@ -124,6 +124,12 @@ function TOOL:RightClick( trace )
 		return
 	end
 
+	-- Check to see if the player can create a hydraulic constraint with the entity in the trace
+	if ( !hook.Run( "CanTool", self:GetOwner(), tr, "hydraulic" ) ) then
+		self:ClearObjects()
+		return
+	end
+		
 	local Phys2 = tr.Entity:GetPhysicsObjectNum( tr.PhysicsBone )
 	self:SetObject( 2, tr.Entity, tr.HitPos, Phys2, tr.PhysicsBone, tr.HitNormal )
 	

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
@@ -118,7 +118,7 @@ function TOOL:RightClick( trace )
 		self:ClearObjects()
 		return
 	end
-	
+
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
@@ -134,6 +134,12 @@ function TOOL:RightClick( trace )
 		return
 	end
 
+	-- Check to see if the player can create a muscle constraint with the entity in the trace
+	if ( !hook.Run( "CanTool", self:GetOwner(), tr, "muscle" ) ) then
+		self:ClearObjects()
+		return
+	end
+	
 	local Phys2 = tr.Entity:GetPhysicsObjectNum( tr.PhysicsBone )
 	self:SetObject( 2, tr.Entity, tr.HitPos, Phys2, tr.PhysicsBone, tr.HitNormal )
 	

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
@@ -81,7 +81,7 @@ function TOOL:RightClick( trace )
 		self:ClearObjects()
 		return
 	end
-	
+
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
@@ -93,6 +93,12 @@ function TOOL:RightClick( trace )
 		return
 	end
 	if ( IsValid( tr.Entity ) && tr.Entity:IsPlayer() ) then
+		self:ClearObjects()
+		return
+	end
+	
+	-- Check to see if the player can create a slider constraint with the entity in the trace
+	if ( !hook.Run( "CanTool", self:GetOwner(), tr, "slider" ) ) then
 		self:ClearObjects()
 		return
 	end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
@@ -95,7 +95,7 @@ function TOOL:RightClick( trace )
 		self:ClearObjects()
 		return
 	end
-	
+
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
@@ -111,6 +111,12 @@ function TOOL:RightClick( trace )
 		return
 	end
 
+	-- Check to see if the player can create a winch constraint with the entity in the trace
+	if ( !hook.Run( "CanTool", self:GetOwner(), tr, "winch" ) ) then
+		self:ClearObjects()
+		return
+	end
+	
 	local Phys2 = tr.Entity:GetPhysicsObjectNum( tr.PhysicsBone )
 	self:SetObject( 2, tr.Entity, tr.HitPos, Phys2, tr.PhysicsBone, trace.HitNormal )
 	


### PR DESCRIPTION
There's been a longstanding issue where players are able to right-click using these 4 tools and create a constraint between a prop they own (according to any arbitrary prop protection system) and a prop they don't own, thus allowing them to essentially take control of the constrained props via dupe, remover, etc.

This is because there is no additional CanTool check to see if the constraint can be made between the exploiter's prop and the prop in the 2nd trace. This pull request adds the additional CanTool check.

Before patch:
1. Player right-clicks their prop.
2. Server checks CanTool to see if the player can tool the prop they are looking at and returns true (they own the prop).
3. Another trace is created pointing back toward the player
4. **A constraint is created between the entity in the 1st trace and the entity in the 2nd trace, regardless of owner.**

After patch:
1. Player right-clicks their prop.
2. Server checks CanTool to see if the player can tool the prop they are looking at and returns true (they own the prop).
3. Another trace is created pointing back toward the player
4. **Server checks CanTool to see if the player can tool the prop the 2nd trace found and returns false (they don't own the prop).**