### PR TITLE
Add player argument to duplicator.IsAllowed

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
@@ -100,7 +100,7 @@ function TOOL:RightClick( trace )
 	duplicator.SetLocalPos( trace.HitPos )
 	duplicator.SetLocalAng( Angle( 0, self:GetOwner():EyeAngles().yaw, 0 ) )
 
-	local Dupe = duplicator.Copy( trace.Entity, false, self:GetOwner() )
+	local Dupe = duplicator.Copy( trace.Entity, nil, self:GetOwner() )
 
 	duplicator.SetLocalPos( Vector( 0, 0, 0 ) )
 	duplicator.SetLocalAng( Angle( 0, 0, 0 ) )

--- a/garrysmod/html/js/menu/control.Menu.js
+++ b/garrysmod/html/js/menu/control.Menu.js
@@ -102,7 +102,7 @@ function MenuController( $scope, $rootScope )
 	// 
 	$scope.BackToGame = function()
 	{
-		lua.Run( "RawConsoleCommand( 'gameui_hide' );" );
+		lua.Run( "gui.HideGameUI()" );
 	}
 
 	$scope.Disconnect = function ()

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -725,6 +725,8 @@ function Paste( Player, EntityList, ConstraintList )
 	-- Create the Entities
 	--
 	for k, v in pairs( EntityList ) do
+		
+		if not IsAllowed(v.Class, Player) then continue end
 	
 		local e = nil
 		local b = ProtectedCall( function() e = CreateEntityFromTable( Player, v ) end )

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -309,7 +309,7 @@ function IsAllowed( classname, Player )
 		return DuplicateAllowed[ classname ]
 	end
 
-	local candupe = hook.Call( "PlayerDupelicateEntity", GAMEMODE, Player, classname )
+	local candupe = hook.Call( "PlayerDuplicateEntity", GAMEMODE, Player, classname )
 	
 	if (candupe != nil) then
 		return candupe	

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -303,8 +303,18 @@ end
 --
 -- Returns true if we can copy/paste this entity
 --
-function IsAllowed( classname )
+function IsAllowed( classname, Player )
 
+	if not Player then
+		return DuplicateAllowed[ classname ]
+	end
+
+	local candupe = hook.Call( "PlayerDupelicateEntity", GAMEMODE, classname, Player )
+	
+	if (candupe != nil) then
+		return candupe	
+	end
+	
 	return DuplicateAllowed[ classname ]
 
 end
@@ -405,7 +415,7 @@ end
 -----------------------------------------------------------]]
 function GenericDuplicatorFunction( Player, data )
 
-	if ( !IsAllowed( data.Class ) ) then
+	if ( !IsAllowed( data.Class, Player ) ) then
 		-- MsgN( "duplicator: ", data.Class, " isn't allowed to be duplicated!" )
 		return
 	end
@@ -546,12 +556,12 @@ end
    Copy this entity, and all of its constraints and entities
    and put them in a table.
 -----------------------------------------------------------]]
-function Copy( Ent, AddToTable )
+function Copy( Ent, AddToTable, Player )
 
 	local Ents = {}
 	local Constraints = {}
 
-	GetAllConstrainedEntitiesAndConstraints( Ent, Ents, Constraints )
+	GetAllConstrainedEntitiesAndConstraints( Ent, Ents, Constraints, Player )
 
 	local EntTables = {}
 	if ( AddToTable != nil ) then EntTables = AddToTable.Entities or {} end
@@ -846,7 +856,7 @@ end
   from outside of this code. It will probably get moved to
   constraint.lua soon.
 -----------------------------------------------------------]]
-function GetAllConstrainedEntitiesAndConstraints( ent, EntTable, ConstraintTable )
+function GetAllConstrainedEntitiesAndConstraints( ent, EntTable, ConstraintTable, Player )
 
 	if ( !IsValid( ent ) ) then return end
 
@@ -855,7 +865,7 @@ function GetAllConstrainedEntitiesAndConstraints( ent, EntTable, ConstraintTable
 	if ( ent.ClassOverride ) then classname = ent.ClassOverride end
 	
 	-- Is the entity in the dupe whitelist?
-	if ( !IsAllowed( classname ) ) then
+	if ( !IsAllowed( classname, Player ) ) then
 		-- MsgN( "duplicator: ", classname, " isn't allowed to be duplicated!" )
 		return
 	end

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -309,7 +309,7 @@ function IsAllowed( classname, Player )
 		return DuplicateAllowed[ classname ]
 	end
 
-	local candupe = hook.Call( "PlayerDupelicateEntity", GAMEMODE, classname, Player )
+	local candupe = hook.Call( "PlayerDupelicateEntity", GAMEMODE, Player, classname )
 	
 	if (candupe != nil) then
 		return candupe	


### PR DESCRIPTION
Adding an argument and hook to the duplicator.IsAllowed function will allow developers to have more control over what can be spawned with the duplicator, as well as who can spawn what. 