### PR TITLE
Fixed menustate error when user has no favorited maps

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -188,7 +188,8 @@ local favmaps
 
 local function LoadFavourites()
 
-	favmaps = favmaps or string.Explode( ";", cookie.GetString( "favmaps", {} ) )
+	local cookiestr = cookie.GetString( "favmaps" )
+	favmaps = favmaps || (cookiestr && string.Explode( ";", cookiestr ) || {})
 
 end
 


### PR DESCRIPTION
```
MENU ERROR: lua/includes/extensions/string.lua:91: bad argument #1 to 'string_gmatch' (string expected, got table)
```
This was due to an empty table being returned in cookie.GetString as the fallback.