### PR TITLE
Removed old ignore patterns

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -194,11 +194,7 @@ local function LoadFavourites()
 end
 
 local IgnorePatterns = {
-	"^background",
-	"^devtest",
-	"^ep1_background",
-	"^ep2_background",
-	"^styleguide",
+	"background"
 }
 
 local IgnoreMaps = {


### PR DESCRIPTION
styleguide and devtest maps were removed from default HL2 packaging; reduced all background maps to one pattern.