### PR TITLE
Fixed detective traitor-finding exploit

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -450,7 +450,7 @@ local function TransferCredits(ply, cmd, args)
    local credits = tonumber(args[2])
    if uid and credits then
       local target = player.GetByUniqueID(uid)
-      if (not IsValid(target)) or (not target:IsActiveSpecial()) or (target == ply) then
+      if (not IsValid(target)) or (not target:IsActiveSpecial()) or (target:GetRole() ~= ply:GetRole()) or (target == ply) then
          LANG.Msg(ply, "xfer_no_recip")
          return
       end


### PR DESCRIPTION
The credit transfer command didn't check if the roles of the two players were the same or not - if you're a detective and willing to toss away your credits, you can run something like this and figure out who all of the traitors are by if the transfer goes through:

```Lua	
for k,v in pairs( player.GetAll() ) do
	if v:IsDetective() then continue end
	RunConsoleCommand( "ttt_transfer_credits", v:UniqueID(), 1 )
end
```

Or you could even hide the fact that you're doing this at all by taking advantage of the credit amount being checked after the recipient (any traitors won't get a "no recipient" message after the "checking" print):

```Lua
for k,v in pairs( player.GetAll() ) do
	if v:IsDetective() then continue end
	timer.Simple( k/5, function()
		if not IsValid(v) then continue end
		print( "Checking " .. v:Nick() )
		RunConsoleCommand( "ttt_transfer_credits", v:UniqueID(), -1 )
	end )
 end
```