### PR TITLE
Cleaned up manifest file and added DoD voices

### DIFF
--- a/garrysmod/scripts/game_sounds_manifest.txt
+++ b/garrysmod/scripts/game_sounds_manifest.txt
@@ -1,10 +1,13 @@
 game_sounds_manifest
 {
+	// Garry's Mod
 	"precache_file"		"scripts/sounds/lua.txt"
-	"precache_file"		"scripts/sounds/cs_game_sounds_radio.txt"
-	"precache_file"		"scripts/sounds/cs_game_sounds_weapons.txt"
-	"precache_file"		"scripts/sounds/dod_game_sounds_weapons.txt"
+	"precache_file"		"scripts/sounds/phx.txt"
+
+	// Half-Life 1
 	"precache_file"		"scripts/sounds/hl1_game_sounds.txt"
+	
+	// Half-Life 2
 	"precache_file"		"scripts/sounds/hl2_game_sounds.txt"
 	"precache_file"		"scripts/sounds/hl2_game_sounds_ambient_generic.txt"
 	"precache_file"		"scripts/sounds/hl2_game_sounds_header.txt"
@@ -16,7 +19,7 @@ game_sounds_manifest
 	"precache_file"		"scripts/sounds/hl2_game_sounds_vehicles.txt"
 	"precache_file"		"scripts/sounds/hl2_game_sounds_weapons.txt"
 	"precache_file"		"scripts/sounds/hl2_game_sounds_world.txt"
-	"precache_file"		"scripts/sounds/l4d_game_sounds_weapons.txt"
+	
 	"precache_file"		"scripts/sounds/level_sounds_breencast.txt"
 	"precache_file"		"scripts/sounds/level_sounds_canals.txt"
 	"precache_file"		"scripts/sounds/level_sounds_canals2.txt"
@@ -65,7 +68,6 @@ game_sounds_manifest
 	"precache_file"		"scripts/sounds/npc_sounds_turret.txt"
 	"precache_file"		"scripts/sounds/npc_sounds_vortigaunt.txt"
 	"precache_file"		"scripts/sounds/npc_sounds_zombie.txt"
-	"precache_file"		"scripts/sounds/phx.txt"
 
 	// Episode 2
 	"precache_file"		"scripts/sounds/game_sounds_addendum_ep2.txt"
@@ -91,7 +93,7 @@ game_sounds_manifest
 	"precache_file"		"scripts/sounds/npc_sounds_strider_episodic2.txt"
 	"precache_file"		"scripts/sounds/npc_sounds_turret_episodic2.txt"
 
-	//Portal
+	// Portal
 	"precache_file"		"scripts/game_sounds_portal.txt"
 	"precache_file"		"scripts/game_sounds_player_portal.txt"
 	"precache_file"		"scripts/game_sounds_weapons_episodic.txt"
@@ -103,6 +105,16 @@ game_sounds_manifest
 	"precache_file"		"scripts/npc_sounds_turret_portal.txt"
 	"precache_file"		"scripts/npc_sounds_rocket_turret.txt"
 	"precache_file"		"scripts/npc_sounds_glados_cores.txt"
+
+	// Counter-Strike: Source
+	"precache_file"		"scripts/sounds/cs_game_sounds_radio.txt"
+	"precache_file"		"scripts/sounds/cs_game_sounds_weapons.txt"
+
+	// Day of Defeat
+	"precache_file"		"scripts/sounds/dod_game_sounds_weapons.txt"
+	
+	"precache_file"  	"scripts/game_sounds_ger_commands.txt"	
+	"precache_file"  	"scripts/game_sounds_us_commands.txt"
 
 	// Episodic content sounds
 	"precache_file"		"scripts/npc_sounds_advisor.txt"
@@ -124,30 +136,34 @@ game_sounds_manifest
 	"precache_file"		"scripts/level_sounds_e3_c17.txt"
 	"precache_file"		"scripts/level_sounds_e3_town.txt"
 	"precache_file"		"scripts/level_sounds_e3_bugbait.txt"
-
+	
 	"precache_file"		"scripts/level_sounds_music_episodic.txt"
 	"precache_file"		"scripts/level_voices_episode_01.txt"
 	
 	"precache_file"		"scripts/level_sounds_aftermath_episodic.txt"
 	"precache_file"		"scripts/level_sounds_c17_02a.txt"
-	
+
 	// Lost coast
 	"precache_file"		"scripts/sounds/level_sounds_lostcoast.txt"
 	"precache_file"		"scripts/sounds/level_voices_lostcoast.txt"
 
 	// Team Fortress 2
-	"precache_file"		"scripts/game_sounds_vo.txt" // These two must not be from TF2
-	"precache_file"  	"scripts/game_sounds_player.txt"
 	"precache_file"		"scripts/sounds/tf2_game_sounds_weapons.txt"
-
+	
 	"precache_file"  	"scripts/game_sounds_mvm.txt"
-//	"preload_file"  	"scripts/game_sounds_vo_mvm.txt"
-//	"preload_file"  	"scripts/game_sounds_vo_mvm_mighty.txt"
+//	"precache_file"  	"scripts/game_sounds_vo_mvm.txt"
+//	"precache_file"  	"scripts/game_sounds_vo_mvm_mighty.txt"
 	"precache_file"  	"scripts/game_sounds_vo_mvm_handmade.txt"
+	
 //	"precache_file" 	"scripts/mvm_level_sounds.txt"
 	"precache_file"  	"scripts/game_sounds_vo_rd_robots.txt"
 	"precache_file"  	"scripts/game_sounds_vo_taunts.txt"
+	
 	"precache_file"		"scripts/game_sounds_taunt_workshop.txt"
+	
 	"precache_file"  	"scripts/game_sounds_vo_pauling.txt"
 	"precache_file"  	"scripts/game_sounds_passtime.txt"
+	
+	// Left 4 Dead
+	"precache_file"		"scripts/sounds/l4d_game_sounds_weapons.txt"
 }


### PR DESCRIPTION
There are currently a lot of sounds missing due to the conflicting names, like game_sounds_player and game_sounds_physics. My thinking is like the weapon sound scripts, just push specific game files with a tag at the beginning to denote the difference.

Also, I have no idea what the difference between precache_file and preload_file is, but we're currently only using precache_file on everything. No idea if that is intentional or not.