### PR TITLE
Fixed instant defusal exploit

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -507,7 +507,7 @@ if SERVER then
       if not idx or not wire then return end
 
       local bomb = ents.GetByIndex(idx)
-      if IsValid(bomb) and bomb:GetArmed() then
+      if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and not bomb.DisarmCausedExplosion and bomb:GetArmed() then
          if bomb:GetPos():Distance(ply:GetPos()) > 256 then
             return
          elseif bomb.SafeWires[wire] or ply:IsTraitor() or ply == bomb:GetOwner() then


### PR DESCRIPTION
When you fail a C4 defuse, it gives you a "tiny moment of zen and realization." The problem is that it still lets you attempts more defuses, so you can spam the defuse command and guarantee a defuse.

It just needs something like this to run to defuse any C4 within 256 units of you:
```Lua
for k,v in pairs(ents.FindByClass("ttt_c4")) do
    for i = 1, 6 do RunConsoleCommand( "ttt_c4_disarm", v:EntIndex(), i ) end
end
```

This commit also stops anyone from making an error pop up by trying to defuse a non-C4 entity (e.g ttt_c4_disarm 1 1).