### PR TITLE
Disable IK for DModelPanel

### DIFF
--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -64,6 +64,7 @@ function PANEL:SetModel( strModelName )
 	if ( !IsValid( self.Entity ) ) then return end
 
 	self.Entity:SetNoDraw( true )
+	self.Entity:SetIK( false )
 
 	-- Try to find a nice sequence to play
 	local iSeq = self.Entity:LookupSequence( "walk_all" )


### PR DESCRIPTION
So the model isn't fucked if the origin of the map is near plane.