### PR TITLE
Nicer error handling for NextBot.RunBehaviour

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/base_nextbot/sv_nextbot.lua
+++ b/garrysmod/gamemodes/base/entities/entities/base_nextbot/sv_nextbot.lua
@@ -20,11 +20,26 @@ function ENT:BehaveUpdate( fInterval )
 
 	if ( !self.BehaveThread ) then return end
 
+	--
+	-- Give a warning to developers if RunBehaviour has returned
+	--
+	if ( coroutine.status( self.BehaveThread ) == "dead" ) then
+
+		self.BehaveThread = nil
+		Msg( self, " Warning: ENT:RunBehaviour() has finished executing\n" )
+
+		return
+
+	end
+
+	--
+	-- Continue RunBehaviour's execution
+	--
 	local ok, message = coroutine.resume( self.BehaveThread )
 	if ( ok == false ) then
 
 		self.BehaveThread = nil
-		Msg( self, "error: ", message, "\n" );
+		ErrorNoHalt( self, " Error: ", message, "\n" );
 
 	end
 


### PR DESCRIPTION
- Prints a little warning to console if ENT:RunBehaviour() stops execution (returns).
- Errors that occur now get passed to ErrorNoHalt. This will be handy if Facepunch/garrysmod-issues#2336 is fixed.

This means that errors inside ENT:RunBehaviour() are no longer silent (supposing the issue is resolved).