### PR TITLE
Fixed excessive balloon force crash

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
@@ -34,7 +34,7 @@ function TOOL:LeftClick( trace, attach )
 	local g = self:GetClientNumber( "g", 0 )
 	local b = self:GetClientNumber( "b", 0 )
 	local model = self:GetClientInfo( "model" )
-	local force = self:GetClientNumber( "force", 500 )
+	local force = math.Clamp( self:GetClientNumber( "force", 500 ), -1E34, 1E34 )
 	local length = self:GetClientNumber( "ropelength", 64 )
 
 	local modeltable = list.Get( "BalloonModels" )[ model ]
@@ -59,7 +59,6 @@ function TOOL:LeftClick( trace, attach )
 	--
 	if	( IsValid( trace.Entity ) && trace.Entity:GetClass() == "gmod_balloon" && trace.Entity.Player == ply ) then
 
-		local force = self:GetClientNumber( "force", 500 )
 		trace.Entity:GetPhysicsObject():Wake()
 		trace.Entity:SetColor( Color( r, g, b, 255 ) )
 		trace.Entity:SetForce( force )
@@ -140,7 +139,9 @@ if ( SERVER ) then
 		balloon:Spawn()
 
 		duplicator.DoGenericPhysics( balloon, pl, Data )
-
+		
+		force = math.Clamp( force, -1E34, 1E34 )
+		
 		balloon:SetRenderMode( RENDERMODE_TRANSALPHA )
 		balloon:SetColor( Color( r, g, b, 255 ) )
 		balloon:SetForce( force )


### PR DESCRIPTION
Similar to the [thruster force crash](https://github.com/garrynewman/garrysmod/commit/6160c8f166828a3c9488b44b02ee61727451e891#diff-d3d6727ecec503cb9f9bd8afff543124]), you can crash servers with balloon force values at 1E35 and above (1E36 on the thruster) or below -1E35.

I've clamped both places where this value is used and removed the redundant code on line 62. I've tested this by both spawning a balloon regularly and by modifying a Duplicator-duped balloon's JSON value to 1E35. Crashes occurred before this patch, and were eliminated after it.