### PR TITLE
Halo render.SuppressEngineLighting

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -65,7 +65,7 @@ local pattern_escape_replacements = {
 
 function string.PatternSafe( str )
 
-	return str:gsub( ".", pattern_escape_replacements )
+	return ( str:gsub( ".", pattern_escape_replacements ) )
 
 end
 

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -61,7 +61,7 @@ function Render( entry )
 			render.SetStencilFailOperation( STENCIL_KEEP )
 			render.SetStencilZFailOperation( STENCIL_KEEP )
 			
-			if v.SuppressLighting then
+			if entry.SuppressLighting then
 				render.SuppressEngineLighting(true)
 			end
 				for k, v in pairs( entry.Ents ) do
@@ -75,7 +75,7 @@ function Render( entry )
 				end
 				
 					RenderEnt = NULL
-			if v.SuppressLighting then
+			if entry.SuppressLighting then
 				render.SuppressEngineLighting(false)
 			end
 			


### PR DESCRIPTION
Lighting is not needed when rendering to a stencil buffer because the model is not visibly drawn. Rather, it writes to the buffer in a boolean format. As such, it's wasted computing power to render lighting on models which will never visibly appear.

Using the following code, I ran benchmark tests for rendering a single blue barrel prop's halo (Entity(42)):

```
//
// RunBenchmark - PRE JUNE 2014 - Josh 'Acecool' Moser
//
function util.Benchmark( _times, func, ... )
	local function benchmark_process( func, ... )
		local x = os.clock( );
		local ret = func( ... );
		local _time = ( os.clock( ) - x );
		MsgC( Color( 0, 255, 255, 255 ), "Benchmark has finished with a total elapsed time of: " .. _time .. "\n" );
		return _time;
	end

	local _time = 0;
	for i = 1, _times do
		_time = _time + benchmark_process( func, ... );
	end

	MsgC( Color( 0, 255, 0, 255 ), "Total Time: \t" .. _time .. "\tseconds\n" );
	MsgC( Color( 0, 255, 0, 255 ), "Average Time: \t" .. _time / _times .. "\tseconds\n" );
end

HALO_RENDER =
			{
				Ents = {Entity(42)},
				Color = Color(255,255,255),
				Hidden = false,
				BlurX = blurx or 2,
				BlurY = blury or 2,
				DrawPasses = passes or 1,
				Additive = false,
				IgnoreZ = false,
				SuppressLighting = true
			}

concommand.Add( "dev_benchload", function( _p, _cmd, _args )
	_p:SendLua([[
		util.Benchmark( 1000, function( )
			halo.Render(HALO_RENDER)
		end )
	]])
end )
```
My results:

WITH LIGHTING:
```
...
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.11099999999999
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Total Time: 	5.354	seconds
Average Time: 	0.005354	seconds
```
SUPPRESSED LIGHTING:
```
...
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Total Time: 	4.8999999999999	seconds
Average Time: 	0.0048999999999999	seconds
```

That's an 8% increase in rendering speed for no change in visual output.
JUST IN CASE there is an unforeseen scenario where it is necessary to compute lighting, it is included as an optional argument which defaults to false.