### PR TITLE
Halo render.SuppressEngineLighting

### DIFF
--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -66,6 +66,8 @@ function Render( entry )
 				render.SetStencilFailOperation( STENCIL_KEEP )
 				render.SetStencilZFailOperation( STENCIL_KEEP )
 
+				render.SuppressEngineLighting(true)
+				
 					for k, v in pairs( entry.Ents ) do
 
 						if ( !IsValid( v ) ) then continue end
@@ -76,6 +78,7 @@ function Render( entry )
 
 					end
 
+				render.SuppressEngineLighting(false)
 					RenderEnt = NULL
 
 				render.SetStencilCompareFunction( STENCIL_EQUAL )

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -55,6 +55,7 @@ function Render( entry )
 	-- Render colored props to the scene and set their pixels high
 	cam.Start3D()
 		render.SetStencilEnable( true )
+			render.SuppressEngineLighting(true)
 			cam.IgnoreZ( entry.IgnoreZ )
 
 				render.SetStencilWriteMask( 1 )
@@ -66,7 +67,6 @@ function Render( entry )
 				render.SetStencilFailOperation( STENCIL_KEEP )
 				render.SetStencilZFailOperation( STENCIL_KEEP )
 
-				render.SuppressEngineLighting(true)
 				
 					for k, v in pairs( entry.Ents ) do
 
@@ -78,7 +78,6 @@ function Render( entry )
 
 					end
 
-				render.SuppressEngineLighting(false)
 					RenderEnt = NULL
 
 				render.SetStencilCompareFunction( STENCIL_EQUAL )
@@ -91,6 +90,7 @@ function Render( entry )
 						surface.DrawRect( 0, 0, ScrW(), ScrH() )
 					cam.End2D()
 
+			render.SuppressEngineLighting(false)
 			cam.IgnoreZ( false )
 		render.SetStencilEnable( false )
 	cam.End3D()

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -90,8 +90,8 @@ function Render( entry )
 						surface.DrawRect( 0, 0, ScrW(), ScrH() )
 					cam.End2D()
 
-			render.SuppressEngineLighting(false)
 			cam.IgnoreZ( false )
+			render.SuppressEngineLighting(false)
 		render.SetStencilEnable( false )
 	cam.End3D()
 


### PR DESCRIPTION
Lighting is not needed when rendering to a stencil buffer because the model is not visibly drawn. Rather, it writes to the buffer in a boolean format. As such, it's wasted computing power to render lighting on models which will never visibly appear.

Using the following code, I ran benchmark tests for rendering a single blue barrel prop's halo (Entity(42)):

```
//
// RunBenchmark - PRE JUNE 2014 - Josh 'Acecool' Moser
//
function util.Benchmark( _times, func, ... )
	local function benchmark_process( func, ... )
		local x = os.clock( );
		local ret = func( ... );
		local _time = ( os.clock( ) - x );
		MsgC( Color( 0, 255, 255, 255 ), "Benchmark has finished with a total elapsed time of: " .. _time .. "\n" );
		return _time;
	end

	local _time = 0;
	for i = 1, _times do
		_time = _time + benchmark_process( func, ... );
	end

	MsgC( Color( 0, 255, 0, 255 ), "Total Time: \t" .. _time .. "\tseconds\n" );
	MsgC( Color( 0, 255, 0, 255 ), "Average Time: \t" .. _time / _times .. "\tseconds\n" );
end

HALO_RENDER =
			{
				Ents = {Entity(42)},
				Color = Color(255,255,255),
				Hidden = false,
				BlurX = blurx or 2,
				BlurY = blury or 2,
				DrawPasses = passes or 1,
				Additive = false,
				IgnoreZ = false,
				SuppressLighting = true
			}

concommand.Add( "dev_benchload", function( _p, _cmd, _args )
	_p:SendLua([[
		util.Benchmark( 1000, function( )
			halo.Render(HALO_RENDER)
		end )
	]])
end )
```
My results:

WITH LIGHTING:
```
...
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.11099999999999
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Total Time: 	5.354	seconds
Average Time: 	0.005354	seconds
```
SUPPRESSED LIGHTING:
```
...
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0.00099999999997635
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Benchmark has finished with a total elapsed time of: 0
Total Time: 	4.8999999999999	seconds
Average Time: 	0.0048999999999999	seconds
```

That's an 8% increase in rendering speed for no change in visual output.