### PR TITLE
Fixed DHTMLControls

### DIFF
--- a/garrysmod/lua/vgui/dhtmlcontrols.lua
+++ b/garrysmod/lua/vgui/dhtmlcontrols.lua
@@ -1,6 +1,6 @@
---[[__                                       _     
- / _| __ _  ___ ___ _ __  _   _ _ __   ___| |__  
-| |_ / _` |/ __/ _ \ '_ \| | | | '_ \ / __| '_ \ 
+--[[__                                       _
+ / _| __ _  ___ ___ _ __  _   _ _ __   ___| |__
+| |_ / _` |/ __/ _ \ '_ \| | | | '_ \ / __| '_ \
 |  _| (_| | (_|  __/ |_) | |_| | | | | (__| | | |
 |_|  \__,_|\___\___| .__/ \__,_|_| |_|\___|_| |_|
                    |_| 2010 --]]
@@ -8,7 +8,7 @@
 local PANEL = {}
 
 --[[---------------------------------------------------------
-	
+
 -----------------------------------------------------------]]
 function PANEL:Init()
 
@@ -21,129 +21,136 @@ function PANEL:Init()
 	self.BackButton:SetMaterial( "gui/HTML/back" )
 	self.BackButton:Dock( LEFT )
 	self.BackButton:DockMargin( Spacing*3, Margins, Spacing, Margins )
-	self.BackButton.DoClick = function() self.BackButton:SetDisabled( true ) self.HTML:HTMLBack(); self.Cur = self.Cur - 1; self.Navigating = true end
-	
+	self.BackButton.DoClick = function()
+		self.BackButton:SetDisabled( true )
+		self.Cur = self.Cur - 1
+		self.Navigating = true
+		self.HTML:GoBack()
+	end
+
 	self.ForwardButton = vgui.Create( "DImageButton", self )
 	self.ForwardButton:SetSize( ButtonSize, ButtonSize )
 	self.ForwardButton:SetMaterial( "gui/HTML/forward" )
 	self.ForwardButton:Dock( LEFT )
 	self.ForwardButton:DockMargin( Spacing, Margins, Spacing, Margins )
-	self.ForwardButton.DoClick = function() self.ForwardButton:SetDisabled( true ) self.HTML:HTMLForward(); self.Cur = self.Cur + 1; self.Navigating = true end
-	
+	self.ForwardButton.DoClick = function()
+		self.ForwardButton:SetDisabled( true )
+		self.Cur = self.Cur + 1
+		self.Navigating = true
+		self.HTML:GoForward()
+	end
+
 	self.RefreshButton = vgui.Create( "DImageButton", self )
 	self.RefreshButton:SetSize( ButtonSize, ButtonSize )
 	self.RefreshButton:SetMaterial( "gui/HTML/refresh" )
 	self.RefreshButton:Dock( LEFT )
 	self.RefreshButton:DockMargin( Spacing, Margins, Spacing, Margins )
-	self.RefreshButton.DoClick = function() self.RefreshButton:SetDisabled( true ) self.Refreshing = true; self.HTML:Refresh() end
-	
+	self.RefreshButton.DoClick = function() self.HTML:Refresh() end
+
 	self.HomeButton = vgui.Create( "DImageButton", self )
 	self.HomeButton:SetSize( ButtonSize, ButtonSize )
 	self.HomeButton:SetMaterial( "gui/HTML/home" )
 	self.HomeButton:Dock( LEFT )
 	self.HomeButton:DockMargin( Spacing, Margins, Spacing*3, Margins )
-	self.HomeButton.DoClick = function() if ( self.HTML.URL == self.HomeURL ) then return end self.HTML:Stop() self.HTML:OpenURL( self.HomeURL ) end
-	
+	self.HomeButton.DoClick = function()
+		if ( self.HTML.URL == self.HomeURL ) then return end
+		self.HTML:Stop()
+		self.HTML:OpenURL( self.HomeURL )
+	end
+
 	self.StopButton = vgui.Create( "DImageButton", self )
 	self.StopButton:SetSize( ButtonSize, ButtonSize )
 	self.StopButton:SetMaterial( "gui/HTML/stop" )
 	self.StopButton:Dock( RIGHT )
 	self.StopButton:DockMargin( Spacing*3, Margins, Spacing*3, Margins )
-	self.StopButton.DoClick = function() self.HTML:Stop() self:FinishedLoading() end
-	
+	self.StopButton.DoClick = function() self.HTML:Stop() end
+
 	self.AddressBar = vgui.Create( "DTextEntry", self )
 	self.AddressBar:Dock( FILL )
 	self.AddressBar:DockMargin( Spacing, Margins * 3, Spacing, Margins * 3 )
-	self.AddressBar.OnEnter = function() self.HTML:Stop() self.HTML:OpenURL( self.AddressBar:GetValue() ) end
-	
+	self.AddressBar.OnEnter = function()
+		self.HTML:Stop()
+		self.HTML:OpenURL( self.AddressBar:GetValue() )
+	end
+
 	self:SetHeight( ButtonSize + Margins * 2 )
-	
-	self.NavStack = 0;
+
 	self.History = {}
 	self.Cur = 1
-	
+
 	-- This is the default look, feel free to change it on your created control :)
 	self:SetButtonColor( Color( 250, 250, 250, 200 ) )
 	self.BorderSize = 4
 	self.BackgroundColor = Color( 40, 40, 40, 255 )
 	self.HomeURL = "http://www.google.com"
-	
-	
 
 end
 
 function PANEL:SetHTML( html )
 
 	self.HTML = html
-	
+
 	if ( html.URL ) then
 		self.HomeURL = self.HTML.URL
 	end
-	
+
 	self.AddressBar:SetText( self.HomeURL )
 	self:UpdateHistory( self.HomeURL )
-	
-	local OldFunc = self.HTML.OpeningURL
-	self.HTML.OpeningURL = function( panel, url, target, postdata, bredirect )
-		
-		self.NavStack = self.NavStack + 1
+
+	local OldFunc = self.HTML.OnBeginLoadingDocument
+	self.HTML.OnBeginLoadingDocument = function( panel, url )
+
 		self.AddressBar:SetText( url )
 		self:StartedLoading()
-		
-		if ( OldFunc ) then
-			OldFunc( panel, url, target, postdata, bredirect )
-		end
-	
-		self:UpdateHistory( url )
-	
-	end
-	
-	local OldFunc = self.HTML.FinishedURL
-	self.HTML.FinishedURL = function( panel, url )
-		
-		self:FinishedLoading()
-		
+
 		if ( OldFunc ) then
 			OldFunc( panel, url )
 		end
-	
+
+		self:UpdateHistory( url )
+
+	end
+
+	local OldFunc = self.HTML.OnFinishLoadingDocument
+	self.HTML.OnFinishLoadingDocument = function( panel, url )
+
+		self:FinishedLoading()
+
+		if ( OldFunc ) then
+			OldFunc( panel, url )
+		end
+
 	end
 
 end
 
 function PANEL:UpdateHistory( url )
 
-	--print( "PANEL:UpdateHistory", url )
 	self.Cur = math.Clamp( self.Cur, 1, table.Count( self.History ) )
-	
-	if ( self.Refreshing ) then
-	
-		self.Refreshing = false
-		self.RefreshButton:SetDisabled( false )
-		return
-		
-	end
-		
+
 	if ( self.Navigating ) then
-			
+
 		self.Navigating = false
 		self:UpdateNavButtonStatus()
-		return;
+		return
 
 	end
-	
+
+	-- Check if we refreshed or hooked into the panel just after creation.
+	if self.History[ self.Cur ] == url then return end
+
 	-- We were back in the history queue, but now we're navigating
 	-- So clear the front out so we can re-write history!!
 	if ( self.Cur < table.Count( self.History ) ) then
-	
+
 		for i=self.Cur+1, table.Count( self.History ) do
 			self.History[i] = nil
 		end
-	
+
 	end
-	
+
 	self.Cur = table.insert( self.History, url )
-	
+
 	self:UpdateNavButtonStatus()
 
 end
@@ -164,8 +171,6 @@ end
 
 function PANEL:UpdateNavButtonStatus()
 
-	--print( self.Cur, table.Count( self.History ) )
-	
 	self.ForwardButton:SetDisabled( self.Cur >= table.Count( self.History ) )
 	self.BackButton:SetDisabled( self.Cur == 1 )
 

--- a/garrysmod/lua/vgui/dhtmlcontrols.lua
+++ b/garrysmod/lua/vgui/dhtmlcontrols.lua
@@ -53,7 +53,7 @@ function PANEL:Init()
 	self.HomeButton:DockMargin( Spacing, Margins, Spacing*3, Margins )
 	self.HomeButton.DoClick = function()
 		if ( self.HTML.URL == self.HomeURL ) then return end
-		self.HTML:Stop()
+		self.HTML:StopLoading()
 		self.HTML:OpenURL( self.HomeURL )
 	end
 
@@ -61,7 +61,7 @@ function PANEL:Init()
 	self.AddressBar:Dock( FILL )
 	self.AddressBar:DockMargin( Spacing, Margins * 3, Margins * 3, Margins * 3 )
 	self.AddressBar.OnEnter = function()
-		self.HTML:Stop()
+		self.HTML:StopLoading()
 		self.HTML:OpenURL( self.AddressBar:GetValue() )
 	end
 
@@ -161,7 +161,7 @@ function PANEL:StartedLoading()
 	self.RefreshStopButton:SetMaterial( "gui/HTML/stop" )
 	self.RefreshStopButton.DoClick = function()
 		self.RefreshStopButton:SetDisabled( true ) -- Awesomium can be slow, let's give some user feedback
-		self.HTML:Stop()
+		self.HTML:StopLoading()
 	end
 
 end

--- a/garrysmod/lua/vgui/dhtmlcontrols.lua
+++ b/garrysmod/lua/vgui/dhtmlcontrols.lua
@@ -40,12 +40,11 @@ function PANEL:Init()
 		self.HTML:GoForward()
 	end
 
-	self.RefreshButton = vgui.Create( "DImageButton", self )
-	self.RefreshButton:SetSize( ButtonSize, ButtonSize )
-	self.RefreshButton:SetMaterial( "gui/HTML/refresh" )
-	self.RefreshButton:Dock( LEFT )
-	self.RefreshButton:DockMargin( Spacing, Margins, Spacing, Margins )
-	self.RefreshButton.DoClick = function() self.HTML:Refresh() end
+	self.RefreshStopButton = vgui.Create( "DImageButton", self )
+	self.RefreshStopButton:SetSize( ButtonSize, ButtonSize )
+	self.RefreshStopButton:SetMaterial( "gui/HTML/refresh" )
+	self.RefreshStopButton:Dock( LEFT )
+	self.RefreshStopButton:DockMargin( Spacing, Margins, Spacing, Margins )
 
 	self.HomeButton = vgui.Create( "DImageButton", self )
 	self.HomeButton:SetSize( ButtonSize, ButtonSize )
@@ -58,16 +57,9 @@ function PANEL:Init()
 		self.HTML:OpenURL( self.HomeURL )
 	end
 
-	self.StopButton = vgui.Create( "DImageButton", self )
-	self.StopButton:SetSize( ButtonSize, ButtonSize )
-	self.StopButton:SetMaterial( "gui/HTML/stop" )
-	self.StopButton:Dock( RIGHT )
-	self.StopButton:DockMargin( Spacing*3, Margins, Spacing*3, Margins )
-	self.StopButton.DoClick = function() self.HTML:Stop() end
-
 	self.AddressBar = vgui.Create( "DTextEntry", self )
 	self.AddressBar:Dock( FILL )
-	self.AddressBar:DockMargin( Spacing, Margins * 3, Spacing, Margins * 3 )
+	self.AddressBar:DockMargin( Spacing, Margins * 3, Margins * 3, Margins * 3 )
 	self.AddressBar.OnEnter = function()
 		self.HTML:Stop()
 		self.HTML:OpenURL( self.AddressBar:GetValue() )
@@ -96,6 +88,7 @@ function PANEL:SetHTML( html )
 
 	self.AddressBar:SetText( self.HomeURL )
 	self:UpdateHistory( self.HomeURL )
+	self:FinishedLoading() -- in case dev adds controls AFTER load
 
 	local OldFunc = self.HTML.OnBeginLoadingDocument
 	self.HTML.OnBeginLoadingDocument = function( panel, url )
@@ -157,15 +150,19 @@ end
 
 function PANEL:FinishedLoading()
 
-	self.StopButton:SetDisabled( true )
-	self.RefreshButton:SetDisabled( false )
+	self.RefreshStopButton:SetDisabled( false )
+	self.RefreshStopButton:SetMaterial( "gui/HTML/refresh" )
+	self.RefreshStopButton.DoClick = function() self.HTML:Refresh() end
 
 end
 
 function PANEL:StartedLoading()
 
-	self.StopButton:SetDisabled( false )
-	self.RefreshButton:SetDisabled( true )
+	self.RefreshStopButton:SetMaterial( "gui/HTML/stop" )
+	self.RefreshStopButton.DoClick = function()
+		self.RefreshStopButton:SetDisabled( true ) -- Awesomium can be slow, let's give some user feedback
+		self.HTML:Stop()
+	end
 
 end
 
@@ -180,9 +177,8 @@ function PANEL:SetButtonColor( col )
 
 	self.BackButton:SetColor( col )
 	self.ForwardButton:SetColor( col )
-	self.RefreshButton:SetColor( col )
+	self.RefreshStopButton:SetColor( col )
 	self.HomeButton:SetColor( col )
-	self.StopButton:SetColor( col )
 
 end
 


### PR DESCRIPTION
After the Awesomium functions and hooks now work/exist, this control can now be fixed. It was pretty much broken at everything except entering URLs into it.

Side notes about the reasoning behind some of the changes:
* `self.Refreshing` was replaced with a URL check as such check was required to prevent a double history insertion on setup. If the controls were hooked before the initial page began loading (likely scenario as `:OpenURL(...)` doesn't start loading immediately) then the history would be appended on setup and again on load. Instead of removing the initial insertion, a history check was added in case someone decided to add the controls later. This also covers refreshes so that special boolean isn't required now.
* `self.NavStack` was useless and is now removed.