### PR TITLE
Added bulk selection checkboxes to addons list

### DIFF
--- a/garrysmod/html/css/menu/PageOptions.css
+++ b/garrysmod/html/css/menu/PageOptions.css
@@ -44,6 +44,11 @@ DIV.page DIV.options, DIV.page DIV.options A
 	text-shadow: 2px 2px 1px #000;
 }
 
+DIV.page DIV.options .submenu
+{
+	font-size: initial;
+}
+
 DIV.page DIV.options .submenu A
 {
 	font-size: 17px;
@@ -53,7 +58,7 @@ DIV.page DIV.options .submenu A
 
 DIV.page DIV.options UL.submenu LI
 {
-	padding: 0;
+	padding: 3px 0;
 	margin: 0;
 }
 
@@ -89,6 +94,11 @@ DIV.page DIV.options.active, DIV.page DIV.options A.active
 	{
 		margin-left: 5px;
 	}
+
+	DIV.page DIV.options UL.submenu LI
+	{
+		padding: 0;
+	}
 }
 
 @media screen and (max-height: 480px) {
@@ -111,5 +121,10 @@ DIV.page DIV.options.active, DIV.page DIV.options A.active
 	{
 		font-size: 20px;
 		line-height: 19px;
+	}
+
+	DIV.page DIV.options UL.submenu LI
+	{
+		padding: 0;
 	}
 }

--- a/garrysmod/html/js/menu/control.Addons.js
+++ b/garrysmod/html/js/menu/control.Addons.js
@@ -30,6 +30,8 @@ function ControllerAddons( $scope, $element, $rootScope, $location )
 		"model"
 	];
 
+	$scope.BulkSelectedIds = {};
+
 	addon.Init( 'addon', $scope, $rootScope );
 
 	$scope.Switch( 'subscribed', 0 );
@@ -80,5 +82,43 @@ function ControllerAddons( $scope, $element, $rootScope, $location )
 	{
 		lua.Run( "steamworks.SetShouldMountAddon( %s, true );", String( file.id ) )
 		lua.Run( "steamworks.ApplyAddons();" )
+	};
+
+	$scope.UnselectAll = function()
+	{
+		$scope.BulkSelectedIds = {};
+	}
+
+	$scope.DisableSelected = function()
+	{
+		Object.keys( $scope.BulkSelectedIds ).forEach(function( id ) {
+			if ( $scope.BulkSelectedIds[ id ] )
+			{
+				lua.Run( "steamworks.SetShouldMountAddon( %s, false )", id );
+			}
+		});
+		lua.Run( "steamworks.ApplyAddons()" );
+	}
+
+	$scope.EnableSelected = function()
+	{
+		Object.keys( $scope.BulkSelectedIds ).forEach(function( id ) {
+			if ( $scope.BulkSelectedIds[ id ] )
+			{
+				lua.Run( "steamworks.SetShouldMountAddon( %s, true )", id );
+			}
+		});
+		lua.Run( "steamworks.ApplyAddons()" );
+	}
+
+	$scope.UnsubscribeSelected = function()
+	{
+		Object.keys( $scope.BulkSelectedIds ).forEach(function( id ) {
+			if ( $scope.BulkSelectedIds[ id ] )
+			{
+				lua.Run( "steamworks.Unsubscribe( %s )", id );
+				delete $scope.BulkSelectedIds[ id ]; // Unselect
+			}
+		});
 	};
 }

--- a/garrysmod/html/template/addon_list.html
+++ b/garrysmod/html/template/addon_list.html
@@ -13,6 +13,16 @@
 					<ul ng-show="Category == 'subscribed'" class="submenu">
 						<li><a ng-click="DisableAllSubscribed()" ng-Tranny="'addons.disableall'"></a></li>
 						<li><a ng-click="EnableAllSubscribed()" ng-Tranny="'addons.enableall'"></a></li>
+						<li>&nbsp;</li>
+						<li><a ng-click="UnselectAll()" ng-Tranny="'addons.unselectall'"></a></li>
+						<li><a ng-click="DisableSelected()" ng-Tranny="'addons.disableselected'"></a></li>
+						<li><a ng-click="EnableSelected()" ng-Tranny="'addons.enableselected'"></a></li>
+						<li>
+							<a ng-click="Unsubscribing = !Unsubscribing" ng-Tranny="'addons.unsubscribeselected'"></a>
+							<ul ng-show="Unsubscribing == true" class="submenu" style="">
+								<li><a ng-click="Unsubscribing = false; UnsubscribeSelected()" ng-Tranny="'addons.confirm'"></a></li>
+							</ul>
+						</li>
 					</ul>
 				</li>
 
@@ -66,7 +76,7 @@
 						<img src='../{{file.background}}' style="width: {{IconMax|number:0}}px; height: {{IconMax|number:0}}px;"/>
 					</preview>
 
-					<name ng-click="OpenWorkshopFile( file.id )">{{file.info.title}}</name>
+					<name ng-click="OpenWorkshopFile( file.id )"><input type="checkbox" ng-model="BulkSelectedIds[ file.id ]" ng-click="$event.stopPropagation()"> {{file.info.title}}</name>
 					<author ng-hide="file.local">{{file.info.ownername}}</author>
 					<votes ng-show="!file.local && (file.vote.up-file.vote.down) > 0" style="color: #4a4">+{{file.vote.up-file.vote.down|number:0}}</votes>
 					<votes ng-show="!file.local && (file.vote.up-file.vote.down) < 0" style="color: #a44">{{file.vote.up-file.vote.down|number:0}}</votes>


### PR DESCRIPTION
Note: there is no "select all" button as the current menu system does not store all subscribed addon IDs in Javascript - only the current page's. I could query Lua for it separately but I'm not sure if that's the best solution.

Some translation strings need adding to Crowdin, with the exception of `addons.confirm`.
