### PR TITLE
Vehicle 3rd-person called several times on client

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/shared.lua
+++ b/garrysmod/gamemodes/base/gamemode/shared.lua
@@ -214,6 +214,11 @@ end
 function GM:VehicleMove( ply, vehicle, mv )
 
 	--
+	-- Prevent calling several times on client
+	--
+	if ( !IsFirstTimePredicted() ) then return end
+	
+	--
 	-- On duck toggle third person view
 	--
 	if ( mv:KeyPressed( IN_DUCK ) ) then


### PR DESCRIPTION
Hi,
I tried to override the 3rd-person change in order to make a tri-state system, but instead of this the view was changed several times per tick on client.
Using `IsFirstTimePredicted()` seems to solve the said issue.

For reference, here's my buggy system:
```lua
hook.Add( "VehicleMove", "prop_teacher_desk", function( ply, vehicle, mv )
	if !IsFirstTimePredicted() then return end
	if rooms_lib and mv:KeyPressed( IN_DUCK ) and vehicle:GetClass()=="prop_vehicle_prisoner_pod" then
		local first = !vehicle:GetThirdPersonMode()
		local desk = vehicle:GetNWEntity( "prop_teacher_desk" )
		if first then
			if IsValid( desk ) then -- enter 3rd-person view
				if CLIENT then ply:ChatPrint( "first(2)" ) end -- debug
				vehicle:SetNWEntity( "prop_teacher_desk", NULL )
			elseif IsValid( ply ) then -- enter 1st-person view with fullscreen if desk found
				if CLIENT then ply:ChatPrint( "first(1)" ) end -- debug
				local room1 = rooms_lib.GetRoom( ply )
				if room1 then
					local room2
					for _,desk in ipairs( ents.FindByClass( "prop_teacher_desk" ) ) do
						room2 = rooms_lib.GetRoom( desk )
						if room2 == room1 then
							vehicle:SetNWEntity( "prop_teacher_desk", desk )
							return true -- do not let the base gamemode switch to 3rd-person view
						end
					end
				end
			end
		else
			if CLIENT then ply:ChatPrint( "!first" ) end -- debug
		end
	end
end )
```