### PR TITLE
Temporary exploit fix

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/shared.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/shared.lua
@@ -99,6 +99,10 @@ end
 -----------------------------------------------------------]]
 function GM:GravGunPickupAllowed( ply, ent )
 
+	if ( ent:IsValid() && ent:GetNWBool( "gravity_disabled", false ) ) then
+		return false
+	end
+
 	if ( ent:IsValid() && ent.GravGunPickupAllowed ) then
 		return ent:GravGunPickupAllowed( ply )
 	end


### PR DESCRIPTION
As described here ( https://facepunch.com/showthread.php?t=1506647 ) there is an exploit that allows players to crash servers by picking up props without gravity using their gravity gun.