### PR TITLE
Fixed DCollapsibleCategory animation sometimes not finishing

### DIFF
--- a/garrysmod/lua/vgui/dcategorycollapse.lua
+++ b/garrysmod/lua/vgui/dcategorycollapse.lua
@@ -298,9 +298,6 @@ function PANEL:AnimSlide( anim, delta, data )
 	if ( anim.Started ) then
 		data.To = self:GetTall()	
 	end
-	
-	if ( anim.Finished ) then
-		return end
 
 	if ( self.Contents ) then self.Contents:SetVisible( true ) end
 	


### PR DESCRIPTION
When the last animation function call is run, anim.Finished will be set to true. The delta has still changed from the last call however so the height still needs to be set. The `if` check here prevented that and only caused problems. The function stops getting called on its own when the animation has nothing more to do.