### PR TITLE
Moved DTextEntry's SetFont call to before SKIN:SchemeTextEntry

### DIFF
--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -55,10 +55,10 @@ function PANEL:Init()
 	-- Beam Me Up Scotty
 	self:SetCursor( "beam" )
 
+	self:SetFont( "DermaDefault" )
+
 	-- Apply scheme settings now, allow the user to override them later.
 	derma.SkinHook( "Scheme", "TextEntry", self )
-
-	self:SetFont( "DermaDefault" )
 
 end
 


### PR DESCRIPTION
This allows people to modify DTextEntry's font in their Derma skins using the `SKIN:SchemeTextEntry` function.