### PR TITLE
Fixed SKIN:SchemeTextEntry not working with Panel:SetSkin

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -453,16 +453,9 @@ function SKIN:PaintTextEntry( panel, w, h )
 		end
 	
 	end
-	
-	panel:DrawTextEntryText( panel.m_colText, panel.m_colHighlight, panel.m_colCursor )
 
-end
 
-function SKIN:SchemeTextEntry( panel ) ---------------------- TODO
-
-	panel:SetTextColor( self.colTextEntryText )
-	panel:SetHighlightColor( self.colTextEntryTextHighlight )
-	panel:SetCursorColor( self.colTextEntryTextCursor )
+	panel:DrawTextEntryText( panel.m_colText || self.colTextEntryText, panel.m_colHighlight || self.colTextEntryTextHighlight, panel.m_colCursor || self.colTextEntryTextCursor )
 
 end
 

--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -57,9 +57,6 @@ function PANEL:Init()
 
 	self:SetFont( "DermaDefault" )
 
-	-- Apply scheme settings now, allow the user to override them later.
-	derma.SkinHook( "Scheme", "TextEntry", self )
-
 end
 
 function PANEL:IsEditing()
@@ -102,7 +99,11 @@ function PANEL:OnKeyCode( code )
 end
 
 function PANEL:ApplySchemeSettings()
+
 	self:SetFontInternal( self.m_FontName )
+
+	derma.SkinHook( "Scheme", "TextEntry", self )
+
 end
 
 function PANEL:UpdateFromHistory()


### PR DESCRIPTION
My last PR worked fine for getting fonts to work - but it only worked if the default skin was changed rather than `Panel:SetSkin`. This wasn't something that broke in my PR - it never worked for text colours either. The reason why it didn't work is that `Panel:SetSkin` is typically called after `vgui.Create` which of course is after `PANEL:Init` and thus after the `SKIN:SchemeTextEntry` call.

This pull request fixes this issue by moving the call to `PANEL:ApplySchemeSettings`, just like it is in other Derma controls. The reason it wasn't there in the first place was based on how the skin's call to set the text colours could override the a call that's done when setting up the panel. This was fixed by doing `||` checks before sending the colours into `Panel:DrawTextEntryText`.

This slight change of behaviour shouldn't break anything but, if possible, **this should be merged before the next update in case someone gets the wrong idea of using `Panel:SetFont` instead of `Panel:SetFontInternal`** in `SKIN:SchemeTextEntry`.