### PR TITLE
Corpses in TTT now look like the dead player

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -376,3 +376,25 @@ function CheckIdle()
       end
    end
 end
+
+function GM:OnEntityCreated(ent)
+   -- Make ragdolls look like the player that has died
+   if ent:IsRagdoll() then
+      local ply = CORPSE.GetPlayer(ent)
+
+      if IsValid(ply) then
+         -- Only copy any decals if this ragdoll was recently created
+         if ent:GetCreationTime() > CurTime() - 1 then
+            ent:SnatchModelInstance(ply)
+         end
+
+         -- Copy the color for the PlayerColor matproxy
+         local playerColor = ply:GetPlayerColor()
+         ent.GetPlayerColor = function()
+            return playerColor
+         end
+      end
+   end
+
+   return self.BaseClass.OnEntityCreated(self, ent)
+end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse_shd.lua
@@ -33,4 +33,7 @@ function CORPSE.GetCredits(rag, default)
    return rag:GetDTInt(dti.INT_CREDITS)
 end
 
-
+function CORPSE.GetPlayer(rag)
+   if not IsValid(rag) then return NULL end
+   return rag:GetDTEntity(dti.ENT_PLAYER)
+end


### PR DESCRIPTION
These changes make corpses copy the colors and decals that were applied to the player that died @svdm. That means green players make green corpses and bloody players make bloody corpses.

It'll only work on the dev branch.