### PR TITLE
Disable patterns in string.find for GAMEMODE.OnChatTab

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -190,7 +190,7 @@ function GM:OnChatTab( str )
 
 		local nickname = v:Nick()
 
-		if ( string.len( LastWord ) < string.len( nickname ) && string.find( string.lower( nickname ), string.lower( LastWord ) ) == 1 ) then
+		if ( string.len( LastWord ) < string.len( nickname ) && string.find( string.lower( nickname ), string.lower( LastWord ), 0, true ) == 1 ) then
 
 			str = string.sub( str, 1, ( string.len( LastWord ) * -1 ) - 1 )
 			str = str .. nickname


### PR DESCRIPTION
Disable patterns in string.find, people might have shit names such as [gay clan name] name

produces this error otherwise: Error in hook OnChatTab: gamemodes/base/gamemode/cl_init.lua:193: malformed pattern (missing ']&apos￼ stack traceback: [C]: in function 'find'