### PR TITLE
Fixed face poser not posing the last flex on some models

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
@@ -47,7 +47,7 @@ function TOOL:Think()
 	local ent = self:FacePoserEntity()
 	if ( !IsValid( ent ) ) then return end
 	
-	local FlexNum = ent:GetFlexNum() - 1
+	local FlexNum = ent:GetFlexNum()
 	if ( FlexNum <= 0 ) then return end
 	
 	for i=0, FlexNum - 1 do


### PR DESCRIPTION
The Face Poser's think function subtracts 1 from the flex count for no reason, making it skip the last flex when applying the values from the convars. Usually, this doesn't matter, since on most models, the last flex is a useless internal thing like a gesture or eye movement flex that the tool would just ignore anyway. On a few models, though, like the TF2 Engineer (both standard and HWM), the last flex isn't useless, but the slider for it in the cpanel doesn't do anything since the think function never applies its value to the model.