### PR TITLE
TTT: CVar weapon spawn amount

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -318,7 +318,7 @@ local function PlaceWeaponsAtEnts(spots_classes)
 
    local spawnables = ents.TTT.GetSpawnableSWEPs()
    
-   local max = GetConVar( "ttt_weapon_spawn_max" ):GetInt()
+   local max = GetConVar( "ttt_weapon_spawn_count" ):GetInt()
    if max == 0 then 
       max = game.MaxPlayers()
       max = max + math.max(3, 0.33 * max)

--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -305,7 +305,8 @@ local function PlaceWeapon(swep, pos, ang)
    return ent
 end
 
--- Spawns a bunch of guns (scaling with playercount) at randomly selected
+-- Spawns a bunch of guns (scaling with maxplayers count or 
+-- by ttt_weapon_spawn_max cvar) at randomly selected
 -- entities of the classes given the table
 local function PlaceWeaponsAtEnts(spots_classes)
    local spots = {}
@@ -316,10 +317,13 @@ local function PlaceWeaponsAtEnts(spots_classes)
    end
 
    local spawnables = ents.TTT.GetSpawnableSWEPs()
-
-   local max = game.MaxPlayers()
-   max = max + math.max(3, 0.33 * max)
-
+   
+   local max = GetConVar( "ttt_weapon_spawn_max" ):GetInt()
+   if max == 0 then 
+      max = game.MaxPlayers()
+	  max = max + math.max(3, 0.33 * max)
+   end
+   
    local num = 0
    local w = nil
    for k, v in RandomPairs(spots) do

--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -321,7 +321,7 @@ local function PlaceWeaponsAtEnts(spots_classes)
    local max = GetConVar( "ttt_weapon_spawn_max" ):GetInt()
    if max == 0 then 
       max = game.MaxPlayers()
-	  max = max + math.max(3, 0.33 * max)
+      max = max + math.max(3, 0.33 * max)
    end
    
    local num = 0

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -95,6 +95,7 @@ CreateConVar("ttt_det_credits_traitordead", "1")
 CreateConVar("ttt_announce_deaths", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 CreateConVar("ttt_use_weapon_spawn_scripts", "1")
+CreateConVar("ttt_weapon_spawn_max", "0")
 
 CreateConVar("ttt_always_use_mapcycle", "0")
 

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -95,7 +95,7 @@ CreateConVar("ttt_det_credits_traitordead", "1")
 CreateConVar("ttt_announce_deaths", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 CreateConVar("ttt_use_weapon_spawn_scripts", "1")
-CreateConVar("ttt_weapon_spawn_max", "0")
+CreateConVar("ttt_weapon_spawn_count", "0")
 
 CreateConVar("ttt_always_use_mapcycle", "0")
 


### PR DESCRIPTION
This feature allows for server owners to control weapon spawn amount on
non populated maps, independent of max players settings.