### PR TITLE
Added hook OnPropertiesMenuOpened

### DIFF
--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -87,6 +87,8 @@ function OpenEntityMenu( ent, tr )
 	end
 	
 	menu:Open()
+	
+	hook.Run( "OnPropertiesMenuOpened", menu )
 
 end
 


### PR DESCRIPTION
This hook will allow for addons to create more advanced properties menus.

At the moment, we can only use properties.Add to add to the properties list and the functionality of it is quite limited.

If we add this hook, it will allow for addons to programmatically change this DermaMenu by being able to add sections and use the DermaMenu functions. This allows for trees of sections (SubMenus), spacer usage (AddSpacer) and more.

The alternative to this is to add more advanced functions to the properties library. In my scenario, I would like to add a small section on the properties list for my latest addon which I would like to have SubMenus and the like.

This cannot be solved by detouring OpenEntityMenu as you would need to access the DermaMenu which is local.