### PR TITLE
Removed duplicated spawnpoints

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -445,7 +445,6 @@ function GM:PlayerSelectSpawn( pl )
 		self.SpawnPoints = table.Add( self.SpawnPoints, ents.FindByClass( "info_player_zombie" ) )
 
 		-- ZM Maps
-		self.SpawnPoints = table.Add( self.SpawnPoints, ents.FindByClass( "info_player_deathmatch" ) )
 		self.SpawnPoints = table.Add( self.SpawnPoints, ents.FindByClass( "info_player_zombiemaster" ) )
 
 	end


### PR DESCRIPTION
This line causes a bug which duplicates the amount of info_player_deathmatch spawnpoints added to the table, thus doubling the chances to be spawned in one of them.