### PR TITLE
Prevent os.date from crashing everything

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -6,7 +6,7 @@
 include ( "util.lua" )			-- Misc Utilities
 include ( "util/sql.lua" )		-- Include sql here so it's
 								-- available at loadtime to modules.
-							
+
 include( "extensions/net.lua" )
 
 --[[---------------------------------------------------------
@@ -123,3 +123,9 @@ if ( CLIENT ) then
 
 end
 
+local osdate = os.date
+function os.date(fstr)
+	return osdate((fstr:gsub('%.', function(s)
+		if not s:find('%[aAbBcdHIjmMpSUwWxXyYZ%]') then return '%'..s end
+	end)), ...)
+end


### PR DESCRIPTION
As described on [the wiki](https://wiki.garrysmod.com/page/os/date), format specifiers not supported by the underlying C runtime will crash the game on Windows.

This makes it so any format string to os.date that includes a non-standard specifier will have that specifier converted to plaintext.