### PR TITLE
Replace deprecated function calls with non-deprecated alternatives

### DIFF
--- a/garrysmod/lua/derma/derma_utils.lua
+++ b/garrysmod/lua/derma/derma_utils.lua
@@ -66,7 +66,7 @@ function Derma_Message( strText, strTitle, strButtonText )
 		
 	local ButtonPanel = vgui.Create( "DPanel", Window )
 		ButtonPanel:SetTall( 30 )
-		ButtonPanel:SetDrawBackground( false )
+		ButtonPanel:SetPaintBackground( false )
 		
 	local Button = vgui.Create( "DButton", ButtonPanel )
 		Button:SetText( strButtonText or "OK" )
@@ -115,7 +115,7 @@ function Derma_Query( strText, strTitle, ... )
 		Window:SetDrawOnTop( true )
 		
 	local InnerPanel = vgui.Create( "DPanel", Window )
-		InnerPanel:SetDrawBackground( false )
+		InnerPanel:SetPaintBackground( false )
 	
 	local Text = vgui.Create( "DLabel", InnerPanel )
 		Text:SetText( strText or "Message Text (Second Parameter)" )
@@ -125,7 +125,7 @@ function Derma_Query( strText, strTitle, ... )
 
 	local ButtonPanel = vgui.Create( "DPanel", Window )
 		ButtonPanel:SetTall( 30 )
-		ButtonPanel:SetDrawBackground( false )
+		ButtonPanel:SetPaintBackground( false )
 
 	-- Loop through all the options and create buttons for them.
 	local NumOptions = 0
@@ -206,7 +206,7 @@ function Derma_StringRequest( strTitle, strText, strDefaultText, fnEnter, fnCanc
 		Window:SetDrawOnTop( true )
 		
 	local InnerPanel = vgui.Create( "DPanel", Window )
-		InnerPanel:SetDrawBackground( false )
+		InnerPanel:SetPaintBackground( false )
 	
 	local Text = vgui.Create( "DLabel", InnerPanel )
 		Text:SetText( strText or "Message Text (Second Parameter)" )
@@ -220,7 +220,7 @@ function Derma_StringRequest( strTitle, strText, strDefaultText, fnEnter, fnCanc
 		
 	local ButtonPanel = vgui.Create( "DPanel", Window )
 		ButtonPanel:SetTall( 30 )
-		ButtonPanel:SetDrawBackground( false )
+		ButtonPanel:SetPaintBackground( false )
 		
 	local Button = vgui.Create( "DButton", ButtonPanel )
 		Button:SetText( strButtonText or "OK" )

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -65,7 +65,7 @@ end
 -----------------------------------------------------------]]
 function meta:IsConstrained()
 
-	if ( CLIENT ) then return self:GetNetworkedBool( "IsConstrained" ) end
+	if ( CLIENT ) then return self:GetNWBool( "IsConstrained" ) end
 
 	local c = self:GetTable().Constraints
 	local bIsConstrained = false
@@ -79,7 +79,7 @@ function meta:IsConstrained()
 
 	end
 
-	self:SetNetworkedBool( "IsConstrained", bIsConstrained )
+	self:SetNWBool( "IsConstrained", bIsConstrained )
 	return bIsConstrained
 
 end

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -161,7 +161,7 @@ end
 function math.BSplinePoint( tDiff, tPoints, tMax )
 	
 	local Q = Vector( 0, 0, 0 );
-	local tinc = tMax / ( table.getn( tPoints ) - 3 );
+	local tinc = tMax / ( #tPoints - 3 );
 	
 	tDiff = tDiff + tinc;
 	

--- a/garrysmod/lua/includes/extensions/player_auth.lua
+++ b/garrysmod/lua/includes/extensions/player_auth.lua
@@ -28,7 +28,7 @@ end
 function meta:IsUserGroup(name)
     if not self:IsValid() then return false end
 
-    return self:GetNetworkedString("UserGroup") == name
+    return self:GetNWString("UserGroup") == name
 end
 
 --[[---------------------------------------------------------
@@ -36,7 +36,7 @@ end
     Desc: Returns the player's usergroup.
 -----------------------------------------------------------]]
 function meta:GetUserGroup()
-    return self:GetNetworkedString("UserGroup", "user")
+    return self:GetNWString("UserGroup", "user")
 end
 
 
@@ -51,7 +51,7 @@ if not SERVER then return end
     Desc: Sets the player's usergroup. ( Serverside Only )
 -----------------------------------------------------------]]
 function meta:SetUserGroup(name)
-    self:SetNetworkedString("UserGroup", name)
+    self:SetNWString("UserGroup", name)
 end
 
 

--- a/garrysmod/lua/includes/modules/effects.lua
+++ b/garrysmod/lua/includes/modules/effects.lua
@@ -28,16 +28,16 @@ function Register( t, name )
 	if ( old != nil ) then
 
 		--
-		-- Foreach entity using this class
+		-- For each entity using this class
 		--
-		table.ForEach( ents.FindByClass( name ), function( _, entity )
+		for _, entity in pairs( ents.FindByClass( name ) ) do
 
 			--
 			-- Replace the contents with this entity table
 			--
 			table.Merge( entity, t )
 
-		end )
+		end
 
 	end
 

--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -138,8 +138,8 @@ local function CheckTextOrTag(p)
 		
 		local text_block = {}
 		text_block.text = p 
-		text_block.colour = colour_stack[ table.getn(colour_stack) ]
-		text_block.font = font_stack[ table.getn(font_stack) ]
+		text_block.colour = colour_stack[ #colour_stack ]
+		text_block.font = font_stack[ #font_stack ]
 		table.insert(blocks, text_block)
 		
 	end

--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -82,9 +82,9 @@ function Register( t, name )
 	if ( old != nil ) then
 
 		--
-		-- Foreach entity using this class
+		-- For each entity using this class
 		--
-		table.ForEach( ents.FindByClass( name ), function( _, entity )
+		for _, entity in pairs( ents.FindByClass( name ) ) do
 
 			--
 			-- Replace the contents with this entity table
@@ -98,7 +98,7 @@ function Register( t, name )
 				entity:OnReloaded()
 			end
 
-		end )
+		end
 
 		-- Update entity table of entities that are based on this entity
 		for _, e in pairs( ents.GetAll() ) do
@@ -141,11 +141,11 @@ function OnLoaded()
 	-- - we have to wait until they're all setup because load order
 	-- could cause some entities to load before their bases!
 	--
-	table.ForEach( SEntList, function( k, v )
+	for k, v in pairs( SEntList ) do
 
 		baseclass.Set( k, Get( k ) )
 
-	end )
+	end
 
 end
 

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -72,9 +72,9 @@ function Register( t, name )
 	if ( old != nil ) then
 
 		--
-		-- Foreach entity using this class
+		-- For each entity using this class
 		--
-		table.ForEach( ents.FindByClass( name ), function( _, entity )
+		for _, entity in pairs( ents.FindByClass( name ) ) do
 
 			--
 			-- Replace the contents with this entity table
@@ -88,7 +88,7 @@ function Register( t, name )
 				entity:OnReloaded()
 			end
 
-		end )
+		end
 
 		-- Update SWEP table of entities that are based on this SWEP
 		for _, e in pairs( ents.GetAll() ) do
@@ -115,11 +115,11 @@ function OnLoaded()
 	-- - we have to wait until they're all setup because load order
 	-- could cause some entities to load before their bases!
 	--
-	table.ForEach( WeaponList, function( k, v )
+	for k, v in pairs( WeaponList ) do
 
 		baseclass.Set( k, Get( k ) )
 
-	end )
+	end
 
 end
 

--- a/garrysmod/lua/postprocess/super_dof.lua
+++ b/garrysmod/lua/postprocess/super_dof.lua
@@ -47,7 +47,7 @@ function PANEL:Init()
 		function self.Distance:OnValueChanged( val ) Distance = val end
 		self.Distance:Dock( TOP )
 		self.Distance:SetDark( true )
-		self.Distance:SetToolTip( "#superdof_pp.distance.tooltip" )
+		self.Distance:SetTooltip( "#superdof_pp.distance.tooltip" )
 		
 	Panel:SetPos( 10, 30 )
 	Panel:SetSize( 300, 90 )

--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -22,7 +22,7 @@ function PANEL:Init()
 	-- Defined above using AccessorFunc
 	--
 	self:SetDrawBorder( true )
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 
 	self:SetTall( 22 )
 	self:SetMouseInputEnabled( true )

--- a/garrysmod/lua/vgui/dcategorycollapse.lua
+++ b/garrysmod/lua/vgui/dcategorycollapse.lua
@@ -61,7 +61,8 @@ local PANEL = {}
 AccessorFunc( PANEL, "m_bSizeExpanded", 		"Expanded", 		FORCE_BOOL )
 AccessorFunc( PANEL, "m_iContentHeight",	 	"StartHeight" )
 AccessorFunc( PANEL, "m_fAnimTime", 			"AnimTime" )
-AccessorFunc( PANEL, "m_bDrawBackground", 		"DrawBackground", 	FORCE_BOOL )
+AccessorFunc( PANEL, "m_bDrawBackground", 		"PaintBackground", 	FORCE_BOOL )
+AccessorFunc( PANEL, "m_bDrawBackground", 		"DrawBackground", 	FORCE_BOOL ) -- deprecated
 AccessorFunc( PANEL, "m_iPadding", 				"Padding" )
 AccessorFunc( PANEL, "m_pList", 				"List" )
 
@@ -81,7 +82,7 @@ function PANEL:Init()
 	self:SetAnimTime( 0.2 )
 	self.animSlide = Derma_Anim( "Anim", self, self.AnimSlide )
 	
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	self:DockMargin( 0, 0, 0, 2 )
 	self:DockPadding( 0, 0, 0, 5 )
 

--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -52,7 +52,7 @@ function PANEL:SetColor( color )
 
 	local colorStr = "R: "..color.r.."\nG: "..color.g.."\nB: "..color.b.."\nA: "..color.a
 
-	self:SetToolTip( colorStr )
+	self:SetTooltip( colorStr )
 	self.m_Color = color
 
 end

--- a/garrysmod/lua/vgui/ddragbase.lua
+++ b/garrysmod/lua/vgui/ddragbase.lua
@@ -11,7 +11,7 @@ function PANEL:Init()
 	self:SetPaintBackgroundEnabled( false )
 	self:SetPaintBorderEnabled( false )
 	self:SetMouseInputEnabled( true )
-	self:SetDrawBackground( false )
+	self:SetPaintBackground( false )
 	
 	self:SetDropPos( "5" )
 	

--- a/garrysmod/lua/vgui/dform.lua
+++ b/garrysmod/lua/vgui/dform.lua
@@ -26,7 +26,7 @@ function PANEL:Init()
 	self:SetSpacing( 4 )
 	self:SetPadding( 10 )
 	
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	
 	self:SetMouseInputEnabled( true )
 	self:SetKeyboardInputEnabled( true )

--- a/garrysmod/lua/vgui/dimagebutton.lua
+++ b/garrysmod/lua/vgui/dimagebutton.lua
@@ -17,7 +17,7 @@ AccessorFunc( PANEL, "m_bStretchToFit", 			"StretchToFit" )
 -----------------------------------------------------------]]
 function PANEL:Init()
 
-	self:SetDrawBackground( false )
+	self:SetPaintBackground( false )
 	self:SetDrawBorder( false )
 	self:SetStretchToFit( true )
 

--- a/garrysmod/lua/vgui/dlabel.lua
+++ b/garrysmod/lua/vgui/dlabel.lua
@@ -15,8 +15,8 @@ AccessorFunc( PANEL, "m_colTextStyle",			"TextStyleColor" )
 AccessorFunc( PANEL, "m_FontName",				"Font" )
 AccessorFunc( PANEL, "m_bDoubleClicking",		"DoubleClickingEnabled",	FORCE_BOOL )
 AccessorFunc( PANEL, "m_bAutoStretchVertical",	"AutoStretchVertical",		FORCE_BOOL )
-AccessorFunc( PANEL, "m_bBackground",			"PaintBackground",			FORCE_BOOL ) -- Why do we have both?
-AccessorFunc( PANEL, "m_bBackground",			"DrawBackground",			FORCE_BOOL ) -- Why do we have both?
+AccessorFunc( PANEL, "m_bBackground",			"PaintBackground",			FORCE_BOOL )
+AccessorFunc( PANEL, "m_bBackground",			"DrawBackground",			FORCE_BOOL ) -- deprecated
 AccessorFunc( PANEL, "m_bHighlight",			"Highlight",				FORCE_BOOL )
 AccessorFunc( PANEL, "m_bIsToggle",				"IsToggle",					FORCE_BOOL )
 AccessorFunc( PANEL, "m_bDisabled",				"Disabled",					FORCE_BOOL )

--- a/garrysmod/lua/vgui/dlistview.lua
+++ b/garrysmod/lua/vgui/dlistview.lua
@@ -43,7 +43,7 @@ function PANEL:Init()
 	self:SetMultiSelect( true )
 	self:SetHideHeaders( false )
 
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	self:SetHeaderHeight( 16 )
 	self:SetDataHeight( 17 )
 

--- a/garrysmod/lua/vgui/dmenu.lua
+++ b/garrysmod/lua/vgui/dmenu.lua
@@ -27,7 +27,7 @@ function PANEL:Init()
 
 	self:SetIsMenu( true )
 	self:SetDrawBorder( true )
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	self:SetMinimumWidth( 100 )
 	self:SetDrawOnTop( true )
 	self:SetMaxHeight( ScrH() * 0.9 )
@@ -178,7 +178,7 @@ end
 -----------------------------------------------------------]]
 function PANEL:Paint( w, h )
 
-	if ( !self:GetDrawBackground() ) then return end
+	if ( !self:GetPaintBackground() ) then return end
 
 	derma.SkinHook( "Paint", "Menu", self, w, h )
 	return true

--- a/garrysmod/lua/vgui/dmenubar.lua
+++ b/garrysmod/lua/vgui/dmenubar.lua
@@ -11,7 +11,7 @@
 local PANEL = {}
 
 AccessorFunc( PANEL, "m_bBackground", 			"PaintBackground",	FORCE_BOOL )
-AccessorFunc( PANEL, "m_bBackground", 			"DrawBackground", 	FORCE_BOOL )
+AccessorFunc( PANEL, "m_bBackground", 			"DrawBackground",	FORCE_BOOL ) -- deprecated
 AccessorFunc( PANEL, "m_bIsMenuComponent", 		"IsMenu", 			FORCE_BOOL )
 
 AccessorFunc( PANEL, "m_bDisabled", 	"Disabled" )
@@ -61,7 +61,7 @@ function PANEL:AddMenu( label )
 	b:Dock( LEFT )
 	b:DockMargin( 5, 0, 0, 0 )
 	b:SetIsMenu( true )
-	b:SetDrawBackground( false )
+	b:SetPaintBackground( false )
 	b:SizeToContentsX( 16 )
 	b.DoClick = function() 
 	

--- a/garrysmod/lua/vgui/dnumberscratch.lua
+++ b/garrysmod/lua/vgui/dnumberscratch.lua
@@ -173,7 +173,7 @@ function PANEL:DrawNotches( level, x, y, w, h, range, value, min, max )
 	local halfw = w * 0.5
 	local span = math.ceil( w / size )
 	local realmid = x + w * 0.5 - (value * self:GetZoom());
-	local mid = x + w * 0.5 - math.mod( value * self:GetZoom(), size );
+	local mid = x + w * 0.5 - math.fmod( value * self:GetZoom(), size );
 	local top = h * 0.4;
 	local nh = h - (top);
 

--- a/garrysmod/lua/vgui/dnumslider.lua
+++ b/garrysmod/lua/vgui/dnumslider.lua
@@ -18,7 +18,7 @@ function PANEL:Init()
 
 	self.TextArea = self:Add( "DTextEntry" )
 	self.TextArea:Dock( RIGHT )
-	self.TextArea:SetDrawBackground( false )
+	self.TextArea:SetPaintBackground( false )
 	self.TextArea:SetWide( 45 )
 	self.TextArea:SetNumeric( true )
 	self.TextArea.OnChange = function( textarea, val ) self:SetValue( self.TextArea:GetText() ) end

--- a/garrysmod/lua/vgui/dpanel.lua
+++ b/garrysmod/lua/vgui/dpanel.lua
@@ -11,7 +11,7 @@
 local PANEL = {}
 
 AccessorFunc( PANEL, "m_bBackground", 			"PaintBackground",	FORCE_BOOL )
-AccessorFunc( PANEL, "m_bBackground", 			"DrawBackground", 	FORCE_BOOL )
+AccessorFunc( PANEL, "m_bBackground", 			"DrawBackground", 	FORCE_BOOL ) -- deprecated
 AccessorFunc( PANEL, "m_bIsMenuComponent", 		"IsMenu", 			FORCE_BOOL )
 AccessorFunc( PANEL, "m_bDisableTabbing", 		"TabbingDisabled", 	FORCE_BOOL )
 

--- a/garrysmod/lua/vgui/dpanellist.lua
+++ b/garrysmod/lua/vgui/dpanellist.lua
@@ -44,7 +44,7 @@ function PANEL:Init()
 	self:SetPadding( 0 )
 	self:EnableHorizontal( false )
 	self:SetAutoSize( false )
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	self:SetNoSizing( false )
 	
 	self:SetMouseInputEnabled( true )

--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -39,7 +39,7 @@ function PANEL:Init()
 	-- Defined above using AccessorFunc
 	--
 	self:SetDrawBorder( true )
-	self:SetDrawBackground( true )
+	self:SetPaintBackground( true )
 	self:SetEnterAllowed( true )
 	self:SetUpdateOnType( false )
 	self:SetNumeric( false )

--- a/garrysmod/lua/vgui/fingervar.lua
+++ b/garrysmod/lua/vgui/fingervar.lua
@@ -170,7 +170,7 @@ function PANEL:Paint( w, h )
 	local wep = LocalPlayer():GetWeapon( "gmod_tool" )
 	if ( !IsValid( wep ) ) then return end
 
-	local ent = wep:GetNetworkedEntity( "HandEntity" )
+	local ent = wep:GetNWEntity( "HandEntity" )
 	if ( !IsValid( ent ) || !ent.FingerIndex ) then return end
 
 	local boneid = ent.FingerIndex[ tonumber( self.VarName:sub( 8 ) ) + 1 + 15 * wep:GetNWInt( "HandNum", 0 ) ]

--- a/garrysmod/lua/vgui/matselect.lua
+++ b/garrysmod/lua/vgui/matselect.lua
@@ -64,7 +64,7 @@ function PANEL:AddMaterial( label, value )
 	Mat.AutoSize = false
 	Mat.Value = value
 	Mat:SetSize( self.ItemWidth, self.ItemHeight )
-	Mat:SetToolTip( label )
+	Mat:SetTooltip( label )
 	
 	-- Run a console command when the Icon is clicked
 	Mat.DoClick = function( button ) 
@@ -106,7 +106,7 @@ function PANEL:AddMaterialEx( label, material, value, convars )
 	Mat.Value = value
 	Mat.ConVars = convars
 	self:SetItemSize( Mat )
-	Mat:SetToolTip( label )
+	Mat:SetTooltip( label )
 	
 	-- Run a console command when the Icon is clicked
 	Mat.DoClick = 	function ( button ) 

--- a/garrysmod/lua/vgui/prop_boolean.lua
+++ b/garrysmod/lua/vgui/prop_boolean.lua
@@ -27,7 +27,7 @@ function PANEL:Setup( vars )
 
 	-- Set the value
 	self.SetValue = function( self, val )
-		ctrl:SetChecked( util.tobool( val ) ) 
+		ctrl:SetChecked( tobool( val ) ) 
 	end
 
 	-- Alert row that value changed

--- a/garrysmod/lua/vgui/prop_generic.lua
+++ b/garrysmod/lua/vgui/prop_generic.lua
@@ -44,7 +44,7 @@ function PANEL:Setup( vars )
 
 	local text = self:Add( "DTextEntry" )
 	if ( !vars || !vars.waitforenter ) then text:SetUpdateOnType( true ) end
-	text:SetDrawBackground( false )
+	text:SetPaintBackground( false )
 	text:Dock( FILL )
 
 	-- Return true if we're editing

--- a/garrysmod/lua/vgui/prop_vectorcolor.lua
+++ b/garrysmod/lua/vgui/prop_vectorcolor.lua
@@ -70,7 +70,7 @@ function PANEL:Setup( vars )
 
 		local menu = DermaMenu()
 			menu:AddPanel( color )
-			menu:SetDrawBackground( false )
+			menu:SetPaintBackground( false )
 		menu:Open( gui.MouseX() + 8, gui.MouseY() + 10 )
 
 	end

--- a/garrysmod/lua/vgui/propselect.lua
+++ b/garrysmod/lua/vgui/propselect.lua
@@ -43,7 +43,7 @@ function PANEL:AddModel( model, ConVars )
 	-- Creeate a spawnicon and set the model
 	local Icon = vgui.Create( "SpawnIcon", self )
 	Icon:SetModel( model )
-	Icon:SetToolTip( model )
+	Icon:SetTooltip( model )
 	Icon.Model = model
 	Icon.ConVars = ConVars or {}
 
@@ -75,7 +75,7 @@ function PANEL:AddModelEx( name, model, skin )
 	-- Creeate a spawnicon and set the model
 	local Icon = vgui.Create( "SpawnIcon", self )
 	Icon:SetModel( model, skin )
-	Icon:SetToolTip( model )
+	Icon:SetTooltip( model )
 	Icon.Model = model
 	Icon.Value = name
 	Icon.ConVars = ConVars or {}

--- a/garrysmod/lua/vgui/spawnicon.lua
+++ b/garrysmod/lua/vgui/spawnicon.lua
@@ -105,9 +105,9 @@ function PANEL:SetModel( mdl, iSkin, BodyGorups )
 	self.Icon:SetModel( mdl, iSkin, BodyGorups )
 	
 	if ( iSkin && iSkin > 0 ) then
-		self:SetToolTip( Format( "%s (Skin %i)", mdl, iSkin+1 ) )
+		self:SetTooltip( Format( "%s (Skin %i)", mdl, iSkin+1 ) )
 	else
-		self:SetToolTip( Format( "%s", mdl ) )
+		self:SetTooltip( Format( "%s", mdl ) )
 	end
 
 end


### PR DESCRIPTION
In this PR I shift usage of deprecated functions in the codebase to their recommended alternatives.
This is an update of #1102.
Notes:
- I kept duplicate accessors (both Set/GetDrawBackground and Set/GetPaintBackground) in panels for compatibility. I also did not alter the internal names of the accessors.
- I did not touch spawnmenu.PopulateFromEngineTextFiles and spawnmenu.DoSaveToTextFiles because using only their base functions breaks things.
- I left the only ProtectedCall call anywhere in the codebase alone, as I have been informed that it is not just an alias. Replacing it with pcall seems to not break anything, but I left it just in case.