### PR TITLE
TTT: Replace deprecated function calls with non-deprecated alternatives

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -164,7 +164,7 @@ function ENT:SphereDamage(dmgowner, center, radius)
    -- efficient to cycle through all those players and do a Lua-side distance
    -- check.
 
-   local r = radius ^ 2 -- square so we can compare with dotproduct directly
+   local r = radius ^ 2 -- square so we can compare with dot product directly
 
 
    -- pre-declare to avoid realloc
@@ -176,7 +176,7 @@ function ENT:SphereDamage(dmgowner, center, radius)
 
          -- dot of the difference with itself is distance squared
          diff = center - ent:GetPos()
-         d = diff:DotProduct(diff)
+         d = diff:Dot(diff)
 
          if d < r then
             -- deadly up to a certain range, then a quick falloff within 100 units
@@ -286,7 +286,7 @@ function ENT:IsDetectiveNear()
       if IsValid(ent) and ent:IsActiveDetective() then
          -- dot of the difference with itself is distance squared
          diff = center - ent:GetPos()
-         d = diff:DotProduct(diff)
+         d = diff:Dot(diff)
 
          if d < r then
             if ent:HasWeapon("weapon_ttt_defuser") then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
@@ -60,7 +60,7 @@ local function RunIgniteTimer(ent, timer_name)
       end
    end
 
-   timer.Destroy(timer_name) -- stop running timer
+   timer.Remove(timer_name) -- stop running timer
 end
 
 local SendScorches
@@ -201,7 +201,7 @@ function SWEP:PrimaryAttack()
    end
 
    if ( (game.SinglePlayer() && SERVER) || CLIENT ) then
-      self:SetNetworkedFloat( "LastShootTime", CurTime() )
+      self:SetNWFloat( "LastShootTime", CurTime() )
    end
 end
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_shotgun.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_shotgun.lua
@@ -51,7 +51,7 @@ end
 
 function SWEP:Reload()
 
-   --if self:GetNetworkedBool( "reloading", false ) then return end
+   --if self:GetNWBool( "reloading", false ) then return end
    if self.dt.reloading then return end
 
    if not IsFirstTimePredicted() then return end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -73,7 +73,7 @@ local function PreqLabels(parent, x, y)
    local tbl = {}
 
    tbl.credits = vgui.Create("DLabel", parent)
-   tbl.credits:SetToolTip(GetTranslation("equip_help_cost"))
+   tbl.credits:SetTooltip(GetTranslation("equip_help_cost"))
    tbl.credits:SetPos(x, y)
    tbl.credits.Check = function(s, sel)
                           local credits = LocalPlayer():GetCredits()
@@ -81,7 +81,7 @@ local function PreqLabels(parent, x, y)
                        end
 
    tbl.owned = vgui.Create("DLabel", parent)
-   tbl.owned:SetToolTip(GetTranslation("equip_help_carry"))
+   tbl.owned:SetTooltip(GetTranslation("equip_help_carry"))
    tbl.owned:CopyPos(tbl.credits)
    tbl.owned:MoveBelow(tbl.credits, y)
    tbl.owned.Check = function(s, sel)
@@ -95,7 +95,7 @@ local function PreqLabels(parent, x, y)
                      end
 
    tbl.bought = vgui.Create("DLabel", parent)
-   tbl.bought:SetToolTip(GetTranslation("equip_help_stock"))
+   tbl.bought:SetTooltip(GetTranslation("equip_help_stock"))
    tbl.bought:CopyPos(tbl.owned)
    tbl.bought:MoveBelow(tbl.owned, y)
    tbl.bought.Check = function(s, sel)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -137,7 +137,6 @@ function CLSCORE:BuildScorePanel(dpanel)
    dlist:SetSortable(true)
    dlist:SetMultiSelect(false)
    dlist:SetPaintBackground(false)
-   dlist:SetDrawBackground(false)
 
    local colnames = {"", "col_player", "col_role", "col_kills1", "col_kills2", "col_points", "col_team", "col_total"}
    for k, name in pairs(colnames) do

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_tbuttons.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_tbuttons.lua
@@ -59,7 +59,7 @@ net.Receive("TTT_ConfirmUseTButton", TBHUD.ReceiveUseConfirm)
 
 local function ComputeRangeFactor(plypos, tgtpos)
    local d = tgtpos - plypos
-   d = d:DotProduct(d)
+   d = d:Dot(d)
    return d / range
 end
 
@@ -94,7 +94,7 @@ function TBHUD:Draw(client)
 
             if (not IsOffScreen(scrpos)) and but:IsUsable() then
                d = pos - plypos
-               d = d:DotProduct(d) / (but:GetUsableRange() ^ 2)
+               d = d:Dot(d) / (but:GetUsableRange() ^ 2)
                -- draw if this button is within range, with alpha based on distance
                if d < 1 then
                   surface.SetDrawColor(255, 255, 255, 200 * (1 - d))

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -560,7 +560,7 @@ local function CreateVoiceVGUI()
     g_VoicePanelList:ParentToHUD()
     g_VoicePanelList:SetPos(25, 25)
     g_VoicePanelList:SetSize(200, ScrH() - 200)
-    g_VoicePanelList:SetDrawBackground(false)
+    g_VoicePanelList:SetPaintBackground(false)
 
     MutedState = vgui.Create("DLabel")
     MutedState:SetPos(ScrW() - 200, ScrH() - 50)

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -302,7 +302,7 @@ local function LastWords(ply, cmd, args)
          if string.len(words) < 2 then return end
 
          -- ignore admin commands
-         local firstchar = string.GetChar(words, 1)
+         local firstchar = string.sub(words, 1, 1)
          if firstchar == "!" or firstchar == "@" or firstchar == "/" then return end
 
 

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -327,7 +327,7 @@ end
 
 local function NameChangeKick()
    if not GetConVar("ttt_namechange_kick"):GetBool() then
-      timer.Destroy("namecheck")
+      timer.Remove("namecheck")
       return
    end
 
@@ -610,7 +610,7 @@ function SpawnWillingPlayers(dead_only)
                      MsgN("Spawned " .. c .. " players in spawn wave.")
 
                      if #to_spawn == 0 then
-                        timer.Destroy("spawnwave")
+                        timer.Remove("spawnwave")
                         MsgN("Spawn waves ending, all players spawned.")
                      end
                   end

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/continuevote.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/continuevote.lua
@@ -25,7 +25,7 @@ function PANEL:Init()
    self.ControlCanvas:SetMouseInputEnabled( false )
 
    self.ctrlList = vgui.Create( "DPanelList", self.ControlCanvas )
-   self.ctrlList:SetDrawBackground( false )
+   self.ctrlList:SetPaintBackground( false )
    self.ctrlList:SetSpacing( 2 )
    self.ctrlList:SetPadding( 2 )
    self.ctrlList:EnableHorizontal( true )

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_info.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_info.lua
@@ -59,7 +59,7 @@ function PANEL:PerformLayout()
    self.List:SetSize(self:GetWide(), 70)
    self.List:SetSpacing(1)
    self.List:SetPadding(2)
-   self.List:SetDrawBackground(false)
+   self.List:SetPaintBackground(false)
 
    self.Scroll:StretchToParent(3,3,3,3)
 
@@ -204,7 +204,7 @@ function PANEL:Init()
    self:SetPaintBackgroundEnabled(false)
    self:SetPaintBorderEnabled(false)
 
-   self:SetDrawBackground(false)
+   self:SetPaintBackground(false)
    self:SetDrawBorder(false)
 
    self:SetFont("treb_small")

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -133,7 +133,7 @@ end
 local function LateLoadout(id)
    local ply = player.GetByID(id)
    if not IsValid(ply) then
-      timer.Destroy("lateloadout" .. id)
+      timer.Remove("lateloadout" .. id)
       return
    end
 
@@ -141,7 +141,7 @@ local function LateLoadout(id)
       GiveLoadoutWeapons(ply)
 
       if HasLoadoutWeapons(ply) then
-         timer.Destroy("lateloadout" .. id)
+         timer.Remove("lateloadout" .. id)
       end
    end
 end
@@ -303,7 +303,7 @@ local function GiveEquipmentWeapon(uid, cls)
    local tmr = "give_equipment" .. tostring(uid)
 
    if (not IsValid(ply)) or (not ply:IsActiveSpecial()) then
-      timer.Destroy(tmr)
+      timer.Remove(tmr)
       return
    end
 
@@ -319,7 +319,7 @@ local function GiveEquipmentWeapon(uid, cls)
       -- we will be retrying
    else
       -- can stop retrying, if we were
-      timer.Destroy(tmr)
+      timer.Remove(tmr)
 
       if w.WasBought then
          -- some weapons give extra ammo after being bought, etc


### PR DESCRIPTION
In this PR I shift usage of deprecated functions in the TTT gamemode codebase to their recommended alternatives.
This is an update of #1102.
See #1162 for more details.