### PR TITLE
faster string.Explode and string.Replace

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -76,28 +76,26 @@ end
 -----------------------------------------------------------]]
 local totable = string.ToTable
 local string_sub = string.sub
-local string_gsub = string.gsub
-local string_gmatch = string.gmatch
+local string_find = string.find
 function string.Explode(separator, str, withpattern)
 	if (separator == "") then return totable( str ) end
-	 
-	local ret = {}
-	local index,lastPosition = 1,1
-	 
-	-- Escape all magic characters in separator
-	if not withpattern then separator = separator:PatternSafe() end
-	 
-	-- Find the parts
-	for startPosition,endPosition in string_gmatch( str, "()" .. separator.."()" ) do
-		ret[index] = string_sub( str, lastPosition, startPosition-1)
-		index = index + 1
-		 
-		-- Keep track of the position
-		lastPosition = endPosition
+
+	if withpattern == nil then
+		withpattern = false
 	end
-	 
-	-- Add last part by using the position we stored
-	ret[index] = string_sub( str, lastPosition)
+
+	local ret = {}
+	local last_pos = 1
+
+	for i = 1, math.huge do
+		local start_pos, end_pos = string_find(str, separator, last_pos, not withpattern)
+		if not start_pos then break end
+		ret[i] = string_sub(str, last_pos, start_pos - 1)
+		last_pos = start_pos + (end_pos - start_pos) + 1
+	end
+
+	ret[#ret + 1] = string_sub(str, last_pos)
+
 	return ret
 end
 

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -237,7 +237,7 @@ function string.Replace( str, tofind, toreplace )
 		return table.concat(tbl, toreplace)
 	end
 
-	return self
+	return str
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -77,6 +77,7 @@ end
 local totable = string.ToTable
 local string_sub = string.sub
 local string_find = string.find
+local string_len = string.len
 function string.Explode(separator, str, withpattern)
 	if (separator == "") then return totable( str ) end
 
@@ -85,16 +86,16 @@ function string.Explode(separator, str, withpattern)
 	end
 
 	local ret = {}
-	local last_pos = 1
+	local current_pos = 1
 
-	for i = 1, math.huge do
-		local start_pos, end_pos = string_find(str, separator, last_pos, not withpattern)
+	for i = 1, string_len(str) do
+		local start_pos, end_pos = string_find(str, separator, current_pos, not withpattern)
 		if not start_pos then break end
-		ret[i] = string_sub(str, last_pos, start_pos - 1)
-		last_pos = start_pos + (end_pos - start_pos) + 1
+		ret[i] = string_sub(str, current_pos, start_pos - 1)
+		current_pos = end_pos + 1
 	end
 
-	ret[#ret + 1] = string_sub(str, last_pos)
+	ret[#ret + 1] = string_sub(str, current_pos)
 
 	return ret
 end

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -231,9 +231,13 @@ end
 
 
 function string.Replace( str, tofind, toreplace )
-	tofind = tofind:PatternSafe()
-	toreplace = toreplace:gsub( "%%", "%%%1" )
-	return ( str:gsub( tofind, toreplace ) )
+	local tbl = string.Explode(tofind, str)
+
+	if tbl[1] then
+		return table.concat(tbl, toreplace)
+	end
+
+	return self
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
I can't test this as gmod doesn't work here but I have tested this outside of gmod and I'm sure the method works. It's about 10 times faster.

There's no need for string.PatternSafe with this method as string.find's third argument can specify whether to do a plain or pattern based search.

I could use `while true do` but `for i = 1, math.huge do ` gives me a free `i`. Now that I'm writing this maybe it could be limited to `string.len(str)` as it would definitely not exceed that.

So I'd like some feedback before this gets merged (obviously) but especially since I can't test this in gmod myself.