### PR TITLE
Major optimization to start round and WEPS.ForcePrecache

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -230,6 +230,10 @@ function GM:InitCvars()
    self.cvar_init = true
 end
 
+function GM:InitPostEntity()
+   WEPS.ForcePrecache()
+end
+
 function GM:GetGameDescription() return self.Name end
 
 -- Convar replication is broken in gmod, so we do this.
@@ -586,11 +590,9 @@ function SpawnWillingPlayers(dead_only)
                      -- spawning
                      while c < num_spawns and #to_spawn > 0 do
                         for k, ply in pairs(to_spawn) do
-                           if IsValid(ply) then
-                              if ply:SpawnForRound() then
-                                 -- a spawn ent is now occupied
-                                 c = c + 1
-                              end
+                           if IsValid(ply) and ply:SpawnForRound() then
+                              -- a spawn ent is now occupied
+                              c = c + 1
                            end
                            -- Few possible cases:
                            -- 1) player has now been spawned
@@ -653,8 +655,6 @@ function BeginRound()
 
    -- Remove their ragdolls
    ents.TTT.RemoveRagdolls(true)
-
-   WEPS.ForcePrecache()
 
    if CheckForAbort() then return end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -486,12 +486,14 @@ end
 -- non-cheat developer commands can reveal precaching the first time equipment
 -- is bought, so trigger it at the start of a round instead
 function WEPS.ForcePrecache()
-   for k, w in pairs(weapons.GetList()) do
-      if w and w.WorldModel then
-         util.PrecacheModel(w.WorldModel)
-      end
-      if w and w.ViewModel then
-         util.PrecacheModel(w.ViewModel)
+   for k, w in ipairs(weapons.GetList()) do
+      if w then
+         if w.WorldModel then
+            util.PrecacheModel(w.WorldModel)
+         end
+         if w.ViewModel then
+            util.PrecacheModel(w.ViewModel)
+         end
       end
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -487,13 +487,11 @@ end
 -- is bought, so trigger it at the start of a round instead
 function WEPS.ForcePrecache()
    for k, w in ipairs(weapons.GetList()) do
-      if w then
-         if w.WorldModel then
-            util.PrecacheModel(w.WorldModel)
-         end
-         if w.ViewModel then
-            util.PrecacheModel(w.ViewModel)
-         end
+      if w.WorldModel then
+         util.PrecacheModel(w.WorldModel)
+      end
+      if w.ViewModel then
+         util.PrecacheModel(w.ViewModel)
       end
    end
 end


### PR DESCRIPTION
Moved WEPS.ForcePrecache to GM.InitPostEntity, switched it's loop from pairs to
ipairs because it is faster and weapons.GetList is sequential, combined two duplicate if statements, and fixed a syntactical issue that really bothered me.

Overall made BeginRound() go from taking about **0.80s** to execute to **0.27s**. This practically removed the little lag at the start of each round.