### PR TITLE
Add SteamID32

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -107,7 +107,8 @@ end
 
 function meta:SteamID32()
 
-	local y,z = string.match( self:SteamID(), "STEAM_0:(%d):(%d+)" )
+	local y, z = 0, 0
+	y,z = string.match( self:SteamID(), "STEAM_0:(%d):(%d+)" )
 
 	return z * 2 + y
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -88,6 +88,31 @@ function player.GetBySteamID64( ID )
 
 end
 
+function player.GetBySteamID32( ID )
+
+	ID = tonumber( ID )
+
+	for _, pl in pairs( player.GetAll() ) do
+
+		if ( pl:SteamID32() == ID ) then
+			return pl
+		end
+
+	end
+
+	return false
+
+end
+
+
+function meta:SteamID32()
+
+	local y,z = string.match( self:SteamID(), "STEAM_0:(%d):(%d+)" )
+
+	return z * 2 + y
+
+end
+
 --[[---------------------------------------------------------
 	Name: DebugInfo
 	Desc: Prints debug information for the player

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -431,3 +431,30 @@ function GetConVarString( name )
 	local c = GetConVarCached( name )
 	return ( c and c:GetString() ) or ""
 end
+
+--[[---------------------------------------------------------
+   Name: SteamIDTo32( steamid )
+   Desc: Given a STEAM_0 style Steam ID will return a 32bit Steam ID
+-----------------------------------------------------------]]
+function util.SteamIDTo32( steamid )
+
+	steamid = tostring( steamid )
+	local y, z = string.match( steamid, "STEAM_0:(%d):(%d+)" )
+
+	return z * 2 + y
+	
+end
+
+--[[---------------------------------------------------------
+   Name: SteamIDFrom32( steamid32 )
+   Desc: Given a 32bit Steam ID will return a STEAM_0 style Steam ID
+-----------------------------------------------------------]]
+function util.SteamIDTo32( steamid32 )
+	
+	steamid32 = tonumber( steamid32 )
+	local y = steamid32 % 2
+	local z = ( steamid32 - y ) / 2
+
+	return "STEAM_0:" .. y .. ":" .. z
+
+end

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -439,7 +439,8 @@ end
 function util.SteamIDTo32( steamid )
 
 	steamid = tostring( steamid )
-	local y, z = string.match( steamid, "STEAM_0:(%d):(%d+)" )
+	local y, z = 0, 0
+	y, z = string.match( steamid, "STEAM_0:(%d):(%d+)" )
 
 	return z * 2 + y
 	

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -449,7 +449,7 @@ end
    Name: SteamIDFrom32( steamid32 )
    Desc: Given a 32bit Steam ID will return a STEAM_0 style Steam ID
 -----------------------------------------------------------]]
-function util.SteamIDTo32( steamid32 )
+function util.SteamIDFrom32( steamid32 )
 	
 	steamid32 = tonumber( steamid32 )
 	local y = steamid32 % 2


### PR DESCRIPTION
https://github.com/Facepunch/garrysmod-issues/issues/2602
This is a potentially a replacement of Player:UnqueID() which doesn't have any collisions.

* No collisions
* Faster than Player:UniqueID
* Number type, therefor faster database queries.
* Smaller database files, since number takes less space than string version of steamid.
* Account comparison, determine which account is older. With Regression Analysis, you can determine how old profile is without querying steam API (also would work with private profiles).

Also `"U:1:" .. util.SteamIDTo32( steamid )` would give you modern steamid (used by games such as CS:GO).