### PR TITLE
Remove "INSTANT KILL" Message for Spectators

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
@@ -278,7 +278,7 @@ if CLIENT then
       local tr = self.Owner:GetEyeTrace(MASK_SHOT)
 
       if tr.HitNonWorld and IsValid(tr.Entity) and tr.Entity:IsPlayer()
-         and tr.Entity:Health() < (self.Primary.Damage + 10) then
+         and tr.Entity:Health() < (self.Primary.Damage + 10)  and self.Owner:Alive() then
 
          local x = ScrW() / 2.0
          local y = ScrH() / 2.0


### PR DESCRIPTION
At the moment, if somebody is spectating a owner of a knife he could see the "INSTANT KILL" Message. And i think it shouldn't be.
With this it'll be removed. This would check if the owner of the knife is alive.

(Sorry, for my bad english. I hope you can understand what i want.)