### PR TITLE
Fixed Spectators can own weapons

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -8,6 +8,7 @@ local IsEquipment = WEPS.IsEquipment
 -- Prevent players from picking up multiple weapons of the same type etc
 function GM:PlayerCanPickupWeapon(ply, wep)
    if not IsValid(wep) and not IsValid(ply) then return end
+   if ply:IsSpec() then return false end
 
    -- Disallow picking up for ammo
    if ply:HasWeapon(wep:GetClass()) then


### PR DESCRIPTION
If the player is joining the server and the round is already in progress he would be able to use weapons.
This can happen without having to get the weapon with one command.
With this it'll be fixed.

(Hope you understand. Google translator isn't good enough for translation descriptions :P)