### PR TITLE
Add Option to mute all players if you are dead

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -573,15 +573,12 @@ local function CreateVoiceVGUI()
 end
 hook.Add( "InitPostEntity", "CreateVoiceVGUI", CreateVoiceVGUI )
 
-MUTE_NONE = 0
-MUTE_TERROR = TEAM_TERROR
-MUTE_SPEC = TEAM_SPEC
-
-local MuteStates = {MUTE_NONE, MUTE_TERROR, MUTE_SPEC}
+local MuteStates = {MUTE_NONE, MUTE_TERROR, MUTE_ALL, MUTE_SPEC}
 
 local MuteText = {
    [MUTE_NONE]   = "",
    [MUTE_TERROR] = "mute_living",
+   [MUTE_ALL]    = "mute_all",
    [MUTE_SPEC]   = "mute_specs"
 };
 

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -186,7 +186,7 @@ function GM:PlayerCanHearPlayersVoice(listener, speaker)
    end
 
    -- Specific mute
-   if listener:IsSpec() and listener.mute_team == speaker:Team() then
+   if listener:IsSpec() and listener.mute_team == speaker:Team() or listener.mute_team == MUTE_ALL then
       return false, false
    end
 
@@ -246,8 +246,13 @@ local function MuteTeam(ply, cmd, args)
    local t = tonumber(args[1])
    ply.mute_team = t
 
-   local name = (t != 0) and team.GetName(t) or "None"
-   ply:ChatPrint(name .. " muted.")
+   if t == MUTE_ALL then
+      ply:ChatPrint("All muted.")
+   elseif t == MUTE_NONE or t == TEAM_UNASSIGNED or not team.Valid(t) then
+      ply:ChatPrint("None muted.")
+   else
+      ply:ChatPrint(team.GetName(t) .. " muted.")
+   end
 end
 concommand.Add("ttt_mute_team", MuteTeam)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
@@ -607,6 +607,7 @@ L.radar_hud    = "Radar ready for next scan in: {time}"
 -- Spectator muting of living/dead
 L.mute_living  = "Living players muted"
 L.mute_specs   = "Spectators muted"
+L.mute_all     = "All muted"
 L.mute_off     = "None muted"
 
 -- Spectators and prop possession

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/german.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/german.lua
@@ -594,6 +594,7 @@ L.radar_hud    = "Radar bereit für nächsten Scan in: {time}"
 -- Spectator muting of living/dead
 L.mute_living  = "Lebende Stumm gestellt"
 L.mute_specs   = "Zuschauer Stumm gestellt"
+L.mute_all     = "Jeden Stumm gestellt"
 L.mute_off     = "Niemanden Stumm gestellt"
 
 -- Spectators and prop possession

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/portuguese.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/portuguese.lua
@@ -604,6 +604,7 @@ L.radar_hud    = "Radar pronto novamente em: {time}"
 -- Spectator muting of living/dead
 L.mute_living  = "Jogadores vivos mutados"
 L.mute_specs   = "Espectadores mutados"
+L.mute_all     = "Todos mutados"
 L.mute_off     = "Ninguém mutado"
 
 -- Spectators and prop possession

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/spanish.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/spanish.lua
@@ -614,6 +614,7 @@ L.radar_hud    = "El radar estará listo en: {time}"
 -- Spectator muting of living/dead
 L.mute_living  = "Jugadores vivos enmudecidos"
 L.mute_specs   = "Espectadores enmudecidos"
+L.mute_all     = "Cada enmudecido"
 L.mute_off     = "Nadie enmudecido"
 
 -- Spectators and prop possession

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -64,6 +64,11 @@ OPEN_ROT  = 2
 OPEN_BUT  = 3
 OPEN_NOTOGGLE = 4 --movelinear
 
+-- Mute types
+MUTE_NONE = 0
+MUTE_TERROR = 1
+MUTE_ALL = 2
+MUTE_SPEC = 1002
 
 COLOR_WHITE  = Color(255, 255, 255, 255)
 COLOR_BLACK  = Color(0, 0, 0, 255)


### PR DESCRIPTION
At the moment you have the ability to mute all spectators or all players who are alive when you are a spectator.
But sometimes i think anyone had the moment where you dont't want to hear the spectators and the players who are alive.
This will add an option to mute all players when you are dead.

(I hope you understand this really bad english.)