### PR TITLE
TTT: Fix possible script error

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -7,7 +7,7 @@ local IsEquipment = WEPS.IsEquipment
 
 -- Prevent players from picking up multiple weapons of the same type etc
 function GM:PlayerCanPickupWeapon(ply, wep)
-   if not IsValid(wep) and not IsValid(ply) then return end
+   if not IsValid(wep) or not IsValid(ply) then return end
    if ply:IsSpec() then return false end
 
    -- Disallow picking up for ammo


### PR DESCRIPTION
Currently the function is only returning if ply and weapon is not valid, but when only player is not valid or only the weapon is not valid, the function will continue and will cause script errors.