### PR TITLE
Fixed SKIN:PaintListView not respecting PaintBackground property

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -957,6 +957,7 @@ end
 
 function SKIN:PaintListView( panel, w, h )
 
+	if ( !panel.m_bBackground ) then return end
 	self.tex.Input.ListBox.Background( 0, 0, w, h )
 
 end


### PR DESCRIPTION
Also applies to the deprecated SetDrawBackground.