### PR TITLE
Fix stack overflow while loading

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -22,7 +22,7 @@ function meta:__index( key )
 	--
 	local tab = self:GetTable()
 	if ( tab ) then
-		local val = tab[ key ]
+		local val = rawget( tab, key )
 		if ( val != nil ) then return val end
 	end
 


### PR DESCRIPTION
Should fix https://github.com/Facepunch/garrysmod-issues/issues/2047

Either way, it's a horrible idea to index yourself inside __index. Why the error happens on line 25 instead of 23, I don't know. GetTable seems to be declared in engine or something because I can't find it.