### PR TITLE
Update net.lua

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -7,7 +7,7 @@ net.Receivers = {}
 --
 function net.Receive( name, func )
 		
-	net.Receivers[ name:lower() ] = func
+	net.Receivers[ name ] = func
 
 end
 
@@ -21,7 +21,7 @@ function net.Incoming( len, client )
 	
 	if ( !strName ) then return end
 	
-	local func = net.Receivers[ strName:lower() ]
+	local func = net.Receivers[ strName ]
 	if ( !func ) then return end
 
 	--


### PR DESCRIPTION
Stop arbitrarily converting all strings to lowercase; it's a big performance drain.

Time taken to index a table with a 20-character string directly: 0.0005 ms
Time taken to index a table with a 20-character string converted to lowercase on-the-fly: 0.15 ms 