### PR TITLE
Fix debug.Trace formatting

### DIFF
--- a/garrysmod/lua/includes/extensions/debug.lua
+++ b/garrysmod/lua/includes/extensions/debug.lua
@@ -34,7 +34,7 @@ function debug.Trace()
 		
 		if (info.what) == "C" then
 		
-			Msg(level, "\tC function\n")
+			Msg( string.format( "\t%i: C function\n", level ) )
 		  
 		else
 		
@@ -46,6 +46,6 @@ function debug.Trace()
 		
 	end
 	  
-	Msg( "\n\n" )
+	Msg( "\n" )
 	  
 end


### PR DESCRIPTION
C functions aren't currently printed with proper formatting.
It's a very minor grievance, but I'd appreciate it if this was fixed.