### PR TITLE
TTT: Fixed edge case where ply:Alive() returns false results

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -7,6 +7,7 @@ local math = math
 
 function plymeta:IsTerror() return self:Team() == TEAM_TERROR end
 function plymeta:IsSpec() return self:Team() == TEAM_SPEC end
+function plymeta:Alive() return self:IsTerror() end
 
 AccessorFunc(plymeta, "role", "Role", FORCE_NUMBER)
 


### PR DESCRIPTION
Sometimes Player:Alive() returns a false result.
For example if you join for the first time.
This would fix this.
I don't think that there are addons which would be broken because of this change.