### PR TITLE
TTT: Fix error when using concommand "wepswitch"

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -177,6 +177,7 @@ end
 
 ---- Weapon switching
 local function ForceWeaponSwitch(ply, cmd, args)
+   if not ply:IsPlayer() or not args[1] then return end
    -- Turns out even SelectWeapon refuses to switch to empty guns, gah.
    -- Worked around it by giving every weapon a single Clip2 round.
    -- Works because no weapon uses those.


### PR DESCRIPTION
If you only run "wepswitch" then an error occurs.
And if you run it as console then the same error occurs.
```
[ERROR] gamemodes/terrortown/gamemode/weaponry.lua:183: attempt to call method 'GetWeapon' (a nil value)
  1. unknown - gamemodes/terrortown/gamemode/weaponry.lua:183
   2. unknown - lua/includes/modules/concommand.lua:54
```
This PR is a possible fix.