### PR TITLE
Base (math-Lib): Changed name from math.Dist function

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -1,15 +1,15 @@
 
 --[[---------------------------------------------------------
-   Name: Dist( low, high )
+   Name: Distance( low, high )
    Desc: Distance between two 2d points
 ------------------------------------------------------------]]
-function math.Dist( x1, y1, x2, y2 )
+function math.Distance( x1, y1, x2, y2 )
 	local xd = x2-x1
 	local yd = y2-y1
 	return math.sqrt( xd*xd + yd*yd )
 end
 
-math.Distance = math.Dist -- alias
+math.Dist = math.Distance -- Backwards compatibility
 
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
According to wiki, the function math.Dist is deprecated.
So I changed everything from this function to math.Distance.
And math.Dist is now the alias from math.Distance.

The source of the information is the Wiki. http://wiki.garrysmod.com/page/math/Dist