### PR TITLE
TTT: Prevent Props be targeted by testers

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -22,9 +22,8 @@ end
 
 
 function ENT:AcceptInput(name, activator)
-   if name == "TestActivator" then
-
-      if IsValid(activator) and activator:IsPlayer() and (self.Role == ROLE_ANY or activator:IsRole(self.Role)) then
+   if name == "TestActivator" and IsValid(activator) and activator:IsPlayer() then
+      if self.Role == ROLE_ANY or activator:IsRole(self.Role) then
          Dev(2, activator, "passed logic_role test of", self:GetName())
          self:TriggerOutput("OnPass", activator)
       else


### PR DESCRIPTION
Example:
If a player (Innocent) the chute used on the Map "ttt_waterworld" for testing and a ragdoll carries with it comes a time the sound that he is Innocent and the other times he's Traitor, because of the ragdoll.
Therefore, would be a general inquiry as to whether the target is a player, in my opinion, from emergencies.

(Google Translator safes my live. xD)