### PR TITLE
TTT: Remove unused things

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -60,14 +60,6 @@ function GM:ChatText(idx, name, text, type)
       end
    end
 
-   if idx == 0 and type == "none" then
-      if string.sub(text, 1, 6) == "(VOTE)" then
-         chat.AddText(Color(255, 180, 0), string.sub(text, 8))
-
-         return true
-      end
-   end
-
    return BaseClass.ChatText(self, idx, name, text, type)
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -92,12 +92,8 @@ CreateConVar("ttt_det_credits_traitorkill", "0")
 CreateConVar("ttt_det_credits_traitordead", "1")
 
 
-CreateConVar("ttt_announce_deaths", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
-
 CreateConVar("ttt_use_weapon_spawn_scripts", "1")
 CreateConVar("ttt_weapon_spawn_count", "0")
-
-CreateConVar("ttt_always_use_mapcycle", "0")
 
 CreateConVar("ttt_round_limit", "6", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED)
 CreateConVar("ttt_time_limit_minutes", "75", FCVAR_NOTIFY + FCVAR_REPLICATED)


### PR DESCRIPTION
I hate GitHub.
I cannot reopen my old pull request.

So finally I'll never touch this hook (TTTDelayRoundStartForVote) again.
@Bo98 found some (in my opinion) very crazy coded mapvotes.
They use this hook. So indeed it seems like that there are people who use this hook.

About mapcycle:
I was a bit iritated because in the ttt home page it says:
> ttt_always_use_mapcycle (def. 0):
Enables the use of your mapcycle.txt even if voting is enabled. Since GMod 13 no voting exists (at the time of writing), so this does nothing.

And in mapcycle.txt it says:
> It is empty because Garry's Mod does not use mapcycle.txt
It only exists so that mapcycle.txt from mountable games ( Portal 2 ) does not load and spam the console with errors

So I thought in isn't really used and I didn't thought about this.
But game.GetMapNext() checks mapcycle.txt
So mapcycle is used in TTT.

Anyway these changes can be made:
- Removing this if-query in cl_voice.lua
- Removing "ttt_announce_deaths"-ConVar
- Removing "ttt_always_use_mapcycle"-ConVar

These things are really not used.
(My old PRs: #1225 and #1223 )

Next time I will take more time for chaning something. So I can test it and search the internet about it.
I apologize if I confused someone. :(