### PR TITLE
TTT: Replace some IsValid(ply) and ply:IsPlayer() with IsPlayer(ply)

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -87,7 +87,7 @@ end
 
 function ENT:Touch(ent)
    if SERVER and self.taken != true then
-      if (ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent)) then
+      if (IsPlayer(ent) and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent)) then
 
          local ammo = ent:GetAmmoCount(self.AmmoType)
          -- need clipmax info and room for at least 1/4th

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -91,7 +91,7 @@ end
 
 
 function ENT:UseOverride(activator)
-   if IsValid(activator) and activator:IsPlayer() then
+   if IsPlayer(activator) then
       -- Traitors not allowed to disarm other traitor's C4 until he is dead
       local owner = self:GetOwner()
       if self:GetArmed() and owner != activator and activator:GetTraitor() and (IsValid(owner) and owner:Alive() and owner:GetTraitor()) then

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_credit_adjust.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_credit_adjust.lua
@@ -20,7 +20,7 @@ end
 function ENT:AcceptInput(name, activator)
    if name == "TakeCredits" then
 
-      if IsValid(activator) and activator:IsPlayer() then
+      if IsPlayer(activator) then
 
          if activator:GetCredits() >= self.Credits then
             activator:SubtractCredits(self.Credits)

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -147,7 +147,7 @@ if CLIENT then
 end
 
 function ENT:UseOverride(activator)
-   if IsValid(activator) and activator:IsPlayer() then
+   if IsPlayer(activator) then
       if activator:IsActiveDetective() and activator:CanCarryType(WEAPON_EQUIP) then
          self:StopScanSound(true)
          self:Remove()

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_damageowner.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_damageowner.lua
@@ -17,7 +17,7 @@ function ENT:AcceptInput(name, activator, caller, data)
    if name == "SetActivatorAsDamageOwner" then
       if not self.Damager then return end
 
-      if IsValid(activator) and activator:IsPlayer() then
+      if IsPlayer(activator) then
          for _, ent in pairs(ents.FindByName(self.Damager) or {}) do
             if IsValid(ent) and ent.SetDamageOwner then
                Dev(2, "Setting damageowner on", ent, ent:GetName())

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_flame.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_flame.lua
@@ -57,7 +57,7 @@ function StartFires(pos, tr, num, lifetime, explode, dmgowner)
 
       local flame = ents.Create("ttt_flame")
       flame:SetPos(pos)
-      if IsValid(dmgowner) and dmgowner:IsPlayer() then
+      if IsPlayer(dmgowner) then
          flame:SetDamageParent(dmgowner)
          flame:SetOwner(dmgowner)
       end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_game_text.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_game_text.lua
@@ -48,7 +48,7 @@ function ENT:AcceptInput(name, activator)
       elseif r == RECEIVE_INNOCENT then
          recv = GetInnocentFilter()
       elseif r == RECEIVE_ACTIVATOR then
-         if not (IsValid(activator) and activator:IsPlayer()) then
+         if not IsPlayer(activator) then
             ErrorNoHalt("ttt_game_text tried to show message to invalid !activator\n")
             return true
          end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -126,7 +126,7 @@ function ENT:GiveHealth(ply, max_heal)
 end
 
 function ENT:Use(ply)
-   if IsValid(ply) and ply:IsPlayer() and ply:IsActive() then
+   if IsPlayer(ply) and ply:IsActive() then
       local t = CurTime()
       if t > self.NextHeal then
          local healed = self:GiveHealth(ply, self.HealRate)

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_knife_proj.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_knife_proj.lua
@@ -127,23 +127,21 @@ end
 
 if SERVER then
   function ENT:Think()
-     if self.Stuck then return end
+      if self.Stuck then return end
 
-     local vel = self:GetVelocity()
-     if vel == vector_origin then return end
+      local vel = self:GetVelocity()
+      if vel == vector_origin then return end
 
-     local tr = util.TraceLine({start=self:GetPos(), endpos=self:GetPos() + vel:GetNormal() * 20, filter={self, self:GetOwner()}, mask=MASK_SHOT_HULL})
+      local tr = util.TraceLine({start=self:GetPos(), endpos=self:GetPos() + vel:GetNormal() * 20, filter={self, self:GetOwner()}, mask=MASK_SHOT_HULL})
+      local other = tr.Entity
 
-     if tr.Hit and tr.HitNonWorld and IsValid(tr.Entity) then
-        local other = tr.Entity
-        if other:IsPlayer() then
-           self:HitPlayer(other, tr)
-        end
-     end
+      if tr.Hit and tr.HitNonWorld and IsPlayer(other) then
+         self:HitPlayer(other, tr)
+      end
 
-     self:NextThink(CurTime())
-     return true
-  end
+      self:NextThink(CurTime())
+      return true
+   end
 end
 
 -- When this entity touches anything that is not a player, it should turn into a
@@ -173,11 +171,11 @@ if SERVER then
       -- if you do fancy stuff in a physics callback
       local knife = self
       timer.Simple(0,
-                   function()
-                      if IsValid(knife) and not knife.Weaponised then
-                         knife:BecomeWeapon()
-                      end
-                   end)
+                     function()
+                        if IsValid(knife) and not knife.Weaponised then
+                           knife:BecomeWeapon()
+                        end
+                     end)
    end
 
    function ENT:PhysicsCollide(data, phys)

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -24,7 +24,7 @@ end
 function ENT:AcceptInput(name, activator)
    if name == "TestActivator" then
 
-      if IsValid(activator) and activator:IsPlayer() and (self.Role == ROLE_ANY or activator:IsRole(self.Role)) then
+      if IsPlayer(activator) and (self.Role == ROLE_ANY or activator:IsRole(self.Role)) then
          Dev(2, activator, "passed logic_role test of", self:GetName())
          self:TriggerOutput("OnPass", activator)
       else

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -45,7 +45,7 @@ function ENT:Initialize()
 end
 
 function ENT:UseOverride(activator)
-   if IsValid(activator) and activator:IsPlayer() and activator:IsActiveTraitor() then
+   if IsPlayer(activator) and activator:IsActiveTraitor() then
       local prints = self.fingerprints or {}
       self:Remove()
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
@@ -93,25 +93,23 @@ function SWEP:PrimaryAttack()
    end
 
 
-   if SERVER and tr.Hit and tr.HitNonWorld and IsValid(hitEnt) then
-      if hitEnt:IsPlayer() then
-         -- knife damage is never karma'd, so don't need to take that into
-         -- account we do want to avoid rounding error strangeness caused by
-         -- other damage scaling, causing a death when we don't expect one, so
-         -- when the target's health is close to kill-point we just kill
-         if hitEnt:Health() < (self.Primary.Damage + 10) then
-            self:StabKill(tr, spos, sdest)
-         else
-            local dmg = DamageInfo()
-            dmg:SetDamage(self.Primary.Damage)
-            dmg:SetAttacker(self.Owner)
-            dmg:SetInflictor(self.Weapon or self)
-            dmg:SetDamageForce(self.Owner:GetAimVector() * 5)
-            dmg:SetDamagePosition(self.Owner:GetPos())
-            dmg:SetDamageType(DMG_SLASH)
+   if SERVER and tr.Hit and tr.HitNonWorld and IsPlayer(hitEnt) then
+      -- knife damage is never karma'd, so don't need to take that into
+      -- account we do want to avoid rounding error strangeness caused by
+      -- other damage scaling, causing a death when we don't expect one, so
+      -- when the target's health is close to kill-point we just kill
+      if hitEnt:Health() < (self.Primary.Damage + 10) then
+         self:StabKill(tr, spos, sdest)
+      else
+         local dmg = DamageInfo()
+         dmg:SetDamage(self.Primary.Damage)
+         dmg:SetAttacker(self.Owner)
+         dmg:SetInflictor(self.Weapon or self)
+         dmg:SetDamageForce(self.Owner:GetAimVector() * 5)
+         dmg:SetDamagePosition(self.Owner:GetPos())
+         dmg:SetDamageType(DMG_SLASH)
 
-            hitEnt:DispatchTraceAttack(dmg, spos + (self.Owner:GetAimVector() * 3), sdest)
-         end
+         hitEnt:DispatchTraceAttack(dmg, spos + (self.Owner:GetAimVector() * 3), sdest)
       end
    end
 
@@ -275,7 +273,7 @@ if CLIENT then
    function SWEP:DrawHUD()
       local tr = self.Owner:GetEyeTrace(MASK_SHOT)
 
-      if tr.HitNonWorld and IsValid(tr.Entity) and tr.Entity:IsPlayer()
+      if tr.HitNonWorld and IsPlayer(tr.Entity)
          and tr.Entity:Health() < (self.Primary.Damage + 10) then
 
          local x = ScrW() / 2.0

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
@@ -42,7 +42,7 @@ SWEP.IronSightsAng         = Vector(2.599, -1.3, -3.6)
 
 function SWEP:SetZoom(state)
    if CLIENT then return end
-   if not (IsValid(self.Owner) and self.Owner:IsPlayer()) then return end
+   if not IsPlayer(self.Owner) then return end
    if state then
       self.Owner:SetFOV(35, 0.5)
    else

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
@@ -108,7 +108,7 @@ function SWEP:FirePulse(force_fwd, force_up)
    local up = force_up / num
    bullet.Callback = function(att, tr, dmginfo)
                         local ply = tr.Entity
-                        if SERVER and IsValid(ply) and ply:IsPlayer() and (not ply:IsFrozen()) then
+                        if SERVER and IsPlayer(ply) and (not ply:IsFrozen()) then
                            local pushvel = tr.Normal * fwd
 
                            pushvel.z = math.max(pushvel.z, up)

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -227,7 +227,7 @@ function SWEP:SecondaryAttack()
 
    local tr = self.Owner:GetEyeTrace(MASK_SHOT)
 
-   if tr.Hit and IsValid(tr.Entity) and tr.Entity:IsPlayer() and (self.Owner:EyePos() - tr.HitPos):Length() < 100 then
+   if tr.Hit and IsPlayer(tr.Entity) and (self.Owner:EyePos() - tr.HitPos):Length() < 100 then
       local ply = tr.Entity
 
       if SERVER and (not ply:IsFrozen()) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -47,7 +47,7 @@ SWEP.IronSightsAng         = Vector( 2.6, 1.37, 3.5 )
 function SWEP:SetZoom(state)
    if CLIENT then
       return
-   elseif IsValid(self.Owner) and self.Owner:IsPlayer() then
+   elseif IsPlayer(self.Owner) then
       if state then
          self.Owner:SetFOV(20, 0.3)
       else

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -198,7 +198,7 @@ local function SpecHUDPaint(client)
    ShadowedText(text, "TimeLeft", time_x + margin, time_y, COLOR_WHITE)
 
    local tgt = client:GetObserverTarget()
-   if IsValid(tgt) and tgt:IsPlayer() then
+   if IsPlayer(tgt) then
       ShadowedText(tgt:Nick(), "TimeLeft", ScrW() / 2, margin, COLOR_WHITE, TEXT_ALIGN_CENTER)
 
    elseif IsValid(tgt) and tgt:GetNWEntity("spec_owner", nil) == client then

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -174,7 +174,7 @@ function PreprocSearch(raw)
          if num == 1 then
             local vic = Entity(d[1])
             local dc = d[1] == -1 -- disconnected
-            if dc or (IsValid(vic) and vic:IsPlayer()) then
+            if dc or IsPlayer(vic) then
                search[t].text = PT("search_kills1", {player = (dc and "<Disconnected>" or vic:Nick())})
             end
          elseif num > 1 then
@@ -184,7 +184,7 @@ function PreprocSearch(raw)
             for k, idx in pairs(d) do
                local vic = Entity(idx)
                local dc = idx == -1
-               if dc or (IsValid(vic) and vic:IsPlayer()) then
+               if dc or IsPlayer(vic) then
                   table.insert(nicks, (dc and "<Disconnected>" or vic:Nick()))
                end
             end
@@ -198,7 +198,7 @@ function PreprocSearch(raw)
       elseif t == "lastid" then
          if d and d.idx != -1 then
             local ent = Entity(d.idx)
-            if IsValid(ent) and ent:IsPlayer() then
+            if IsPlayer(ent) then
                search[t].text = PT("search_eyes", {player = ent:Nick()})
 
                search[t].ply = ent
@@ -439,7 +439,7 @@ local function ReceiveRagdollSearch()
    search.eidx = net.ReadUInt(16)
 
    search.owner = Entity(net.ReadUInt(8))
-   if not (IsValid(search.owner) and search.owner:IsPlayer() and (not search.owner:Alive())) then
+   if not (IsPlayer(search.owner) and (not search.owner:Alive())) then
       search.owner = nil
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -250,7 +250,7 @@ function RADIO:GetTargetType()
 
    local ent = trace.Entity
 
-   if ent:IsPlayer() and  ent:IsTerror() then
+   if ent:IsPlayer() and ent:IsTerror() then
       if ent:GetNWBool("disguised", false) then
          return "quick_disg", true
       else
@@ -365,7 +365,7 @@ local function RadioMsgRecv()
    local msg    = net.ReadString()
    local param  = net.ReadString()
 
-   if not (IsValid(sender) and sender:IsPlayer()) then return end
+   if not IsPlayer(sender) then return end
 
    GAMEMODE:PlayerSentRadioCommand(sender, msg, param)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -287,7 +287,7 @@ local function GetKillerSample(victim, attacker, dmg)
       return nil
    end
 
-   if not (IsValid(victim) and IsValid(attacker) and attacker:IsPlayer()) then return end
+   if not (IsValid(victim) and IsPlayer(attacker)) then return end
 
    -- NPCs for which a player is damage owner (meaning despite the NPC dealing
    -- the damage, the attacker is a player) should not cause the player's DNA to
@@ -342,7 +342,7 @@ local function GetSceneData(victim, attacker, dmginfo)
 
    scene.victim = GetSceneDataFromPlayer(victim)
 
-   if IsValid(attacker) and attacker:IsPlayer() then
+   if IsPlayer(attacker) then
       scene.killer = GetSceneDataFromPlayer(attacker)
 
       local att = attacker:LookupAttachment("anim_attachment_RH")

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -295,7 +295,7 @@ local function LastWords(ply, cmd, args)
          local last_seen = tonumber(args[2])
          if last_seen then
             local ent = Entity(last_seen)
-            if IsValid(ent) and ent:IsPlayer() and rag and (not rag.lastid) then
+            if IsPlayer(ent) and rag and (not rag.lastid) then
                rag.lastid = {ent=ent, t=CurTime()}
             end
          end

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -110,9 +110,8 @@ end
 -- been applied to the victim yet, but must have been scaled according to the
 -- damage factor of the attacker.
 function KARMA.Hurt(attacker, victim, dmginfo)
-   if not IsValid(attacker) or not IsValid(victim) then return end
+   if not IsPlayer(attacker) or not IsPlayer(victim) then return end
    if attacker == victim then return end
-   if not attacker:IsPlayer() or not victim:IsPlayer() then return end
 
    -- Ignore excess damage
    local hurt_amount = math.min(victim:Health(), dmginfo:GetDamage())
@@ -142,9 +141,8 @@ end
 
 -- Handle karma change due to one player killing another.
 function KARMA.Killed(attacker, victim, dmginfo)
-   if not IsValid(attacker) or not IsValid(victim) then return end
+   if not IsPlayer(attacker) or not IsPlayer(victim) then return end
    if attacker == victim then return end
-   if not attacker:IsPlayer() or not victim:IsPlayer() then return end
 
    if attacker:GetTraitor() == victim:GetTraitor() then
       -- don't penalise attacker for stupid victims

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -342,7 +342,7 @@ local oldSpectateEntity = plymeta.SpectateEntity
 function plymeta:SpectateEntity(ent)
    oldSpectateEntity(self, ent)
 
-   if IsValid(ent) and ent:IsPlayer() then
+   if IsPlayer(ent) then
       self:SetupHands(ent)
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
@@ -56,7 +56,7 @@ local function CopyDmg(dmg)
 end
 
 function SCORE:HandleKill( victim, attacker, dmginfo )
-   if not (IsValid(victim) and victim:IsPlayer()) then return end
+   if not IsPlayer(victim) then return end
 
    local e = {
       id=EVENT_KILL,
@@ -68,7 +68,7 @@ function SCORE:HandleKill( victim, attacker, dmginfo )
 
    e.vic.tr = victim:GetTraitor()
 
-   if IsValid(attacker) and attacker:IsPlayer() then
+   if IsPlayer(attacker) then
       e.att.ni = attacker:Nick()
       e.att.sid = attacker:SteamID()
       e.att.tr = attacker:GetTraitor()
@@ -112,7 +112,7 @@ end
 
 function SCORE:HandleC4Explosion(planter, arm_time, exp_time)
    local nick = "Someone"
-   if IsValid(planter) and planter:IsPlayer() then
+   if IsPlayer(planter) then
       nick = planter:Nick()
    end
 


### PR DESCRIPTION
Changes made:
- garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua:
 - Replaced `ent:IsValid() and ent:IsPlayer()` with `IsPlayer(ent)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_credit_adjust.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`- garrysmod/gamemodes/terrortown/entities/entities/ttt_damageowner.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_flame.lua:
 - Replaced `IsValid(dmgowner) and dmgowner:IsPlayer()` with `IsPlayer(dmgowner)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_game_text.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua:
 - Replaced `IsValid(ply) and ply:IsPlayer()` with `IsPlayer(ply)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_knife_proj.lua:
 - Replaced `IsValid(other) and other:IsPlayer()` with `IsPlayer(other)`
 - Corrected some spaces
- garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua:
 - Replaced `IsValid(activator) and activator:IsPlayer()` with `IsPlayer(activator)`
- garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua:
 - Replaced `IsValid(tr.Entity) and hitEnt:IsPlayer()` with `IsPlayer(tr.Entity)`
- garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua:
 - Replaced `IsValid(self.Owner) and self.Owner:IsPlayer()` with `IsPlayer(self.Owner)`
- garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua:
 - Replaced `IsValid(ply) and ply:IsPlayer()` with `IsPlayer(ply)`
- garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua:
 - Replaced `IsValid(tr.Entity) and hitEnt:IsPlayer()` with `IsPlayer(tr.Entity)`
- garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua:
 - Replaced `IsValid(self.Owner) and self.Owner:IsPlayer()` with `IsPlayer(self.Owner)`
- garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua:
 - Replaced `IsValid(tgt) and tgt:IsPlayer()` with `IsPlayer(tgt)`
- garrysmod/gamemodes/terrortown/gamemode/cl_search.lua:
 - Replaced `IsValid(vic) and vic:IsPlayer()` with `IsPlayer(vic)`
- garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua:
 - Replaced `IsValid(sender) and sender:IsPlayer()` with `IsPlayer(sender)`
 - corrected some spaces
- garrysmod/gamemodes/terrortown/gamemode/corpse.lua:
 - Replaced `IsValid(attacker) and attacker:IsPlayer()` with `IsPlayer(attacker)`
- garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua:
 - Replaced `IsValid(ent) and ent:IsPlayer()` with `IsPlayer(ent)`
- garrysmod/gamemodes/terrortown/gamemode/karma.lua:
 - replaced some if-queries
- garrysmod/gamemodes/terrortown/gamemode/player.lua:
 - replaced `IsValid(tgt) and tgt:IsPlayer()` with `IsPlayer(tgt)`
- garrysmod/gamemodes/terrortown/gamemode/player_ext.lua:
 - Replaced `IsValid(ent) and ent:IsPlayer()` with `IsPlayer(ent)`
- garrysmod/gamemodes/terrortown/gamemode/scoring.lua:
 - Replaced `IsValid(attacker) and attacker:IsPlayer()` with `IsPlayer(attacker)`

In some cases I replaced more than one IsValid(ply)...
Just too lazy to count it here.
These changes aren't necessary.
I have just made them, because I just had the time for it and my opinion is that if TTT already has this functions, they should also be used.
And because I have too much time and I don't know how to pass it :3.