### PR TITLE
TTT: Remove unused var and fix a small issue

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
@@ -56,6 +56,9 @@ function SWEP:Deploy()
    if SERVER and IsValid(self.Owner) then
       self.Owner:DrawViewModel(false)
    end
+
+   self:DrawShadow(false)
+
    return true
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -372,7 +372,6 @@ local function ShowSearchScreen(search_raw)
 
       -- Certain items need a special icon conveying additional information
       if t == "nick" then
-         local name = info.nick
          local avply = IsValid(search_raw.owner) and search_raw.owner or nil
 
          ic = vgui.Create("SimpleIconAvatar", dlist)
@@ -439,7 +438,7 @@ local function ReceiveRagdollSearch()
    search.eidx = net.ReadUInt(16)
 
    search.owner = Entity(net.ReadUInt(8))
-   if not (IsValid(search.owner) and search.owner:IsPlayer() and (not search.owner:Alive())) then
+   if not (IsValid(search.owner) and search.owner:IsPlayer() and (not search.owner:IsTerror())) then
       search.owner = nil
    end
 


### PR DESCRIPTION
Just removed a useless var and fixed a small issue.

If you die a corpse will be created. (obvious)
If you reconnect, after your death, then the steam avatar wouldn't be shown in the corpse because after reconnecting Player:Alive() is returning a false result.