### PR TITLE
Added fallback for ammo item pickup name if no language string is ava…

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
@@ -84,7 +84,7 @@ function GM:HUDAmmoPickedUp( itemname, amount )
 	end
 
 	-- Try to tack it onto an exisiting ammo pickup
-	for k, v in ipairs( self.PickupHistory ) do
+	for k, v in pairs( self.PickupHistory ) do
 
 		if ( v.name == ammoname ) then
 
@@ -131,7 +131,7 @@ function GM:HUDDrawPickupHistory()
 	local tall = 0
 	local wide = 0
 
-	for k, v in ipairs( self.PickupHistory ) do
+	for k, v in pairs( self.PickupHistory ) do
 
 		if ( !istable( v ) ) then
 

--- a/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_hudpickup.lua
@@ -13,8 +13,7 @@ function GM:HUDWeaponPickedUp( wep )
 
 	if ( !IsValid( LocalPlayer() ) || !LocalPlayer():Alive() ) then return end
 	if ( !IsValid( wep ) ) then return end
-	if ( !isfunction( wep.GetPrintName ) ) then return end
-		
+
 	local pickup = {}
 	pickup.time			= CurTime()
 	pickup.name			= wep:GetPrintName()
@@ -23,7 +22,7 @@ function GM:HUDWeaponPickedUp( wep )
 	pickup.fadein		= 0.04
 	pickup.fadeout		= 0.3
 	pickup.color		= Color( 255, 200, 50, 255 )
-	
+
 	surface.SetFont( pickup.font )
 	local w, h = surface.GetTextSize( pickup.name )
 	pickup.height		= h
@@ -32,7 +31,7 @@ function GM:HUDWeaponPickedUp( wep )
 	if ( self.PickupHistoryLast >= pickup.time ) then
 		pickup.time = self.PickupHistoryLast + 0.05
 	end
-	
+
 	table.insert( self.PickupHistory, pickup )
 	self.PickupHistoryLast = pickup.time
 
@@ -45,7 +44,7 @@ end
 function GM:HUDItemPickedUp( itemname )
 
 	if ( !IsValid( LocalPlayer() ) || !LocalPlayer():Alive() ) then return end
-	
+
 	local pickup = {}
 	pickup.time			= CurTime()
 	pickup.name			= "#"..itemname
@@ -54,7 +53,7 @@ function GM:HUDItemPickedUp( itemname )
 	pickup.fadein		= 0.04
 	pickup.fadeout		= 0.3
 	pickup.color		= Color( 180, 255, 180, 255 )
-	
+
 	surface.SetFont( pickup.font )
 	local w, h = surface.GetTextSize( pickup.name )
 	pickup.height		= h
@@ -63,7 +62,7 @@ function GM:HUDItemPickedUp( itemname )
 	if ( self.PickupHistoryLast >= pickup.time ) then
 		pickup.time = self.PickupHistoryLast + 0.05
 	end
-	
+
 	table.insert( self.PickupHistory, pickup )
 	self.PickupHistoryLast = pickup.time
 
@@ -76,40 +75,42 @@ end
 function GM:HUDAmmoPickedUp( itemname, amount )
 
 	if ( !IsValid( LocalPlayer() ) || !LocalPlayer():Alive() ) then return end
-	
-	-- Try to tack it onto an exisiting ammo pickup
-	if ( self.PickupHistory ) then
-	
-		for k, v in pairs( self.PickupHistory ) do
-	
-			if ( v.name == "#" .. itemname .. "_ammo" ) then
-			
-				v.amount = tostring( tonumber( v.amount ) + amount )
-				v.time = CurTime() - v.fadein
-				return
-				
-			end
-	
-		end
-	
+
+	local ammoname = "#" .. itemname .. "_ammo"
+	if ( ammoname == language.GetPhrase( ammoname ) ) then
+
+		ammoname = itemname .. " ammo"
+
 	end
-	
-		
+
+	-- Try to tack it onto an exisiting ammo pickup
+	for k, v in ipairs( self.PickupHistory ) do
+
+		if ( v.name == ammoname ) then
+
+			v.amount = tostring( tonumber( v.amount ) + amount )
+			v.time = CurTime() - v.fadein
+			return
+
+		end
+
+	end
+
 	local pickup = {}
 	pickup.time			= CurTime()
-	pickup.name			= "#" .. itemname .. "_ammo"
+	pickup.name			= ammoname
 	pickup.holdtime		= 5
 	pickup.font			= "DermaDefaultBold"
 	pickup.fadein		= 0.04
 	pickup.fadeout		= 0.3
 	pickup.color		= Color( 180, 200, 255, 255 )
 	pickup.amount		= tostring( amount )
-	
+
 	surface.SetFont( pickup.font )
 	local w, h = surface.GetTextSize( pickup.name )
 	pickup.height	= h
 	pickup.width	= w
-	
+
 	local w, h = surface.GetTextSize( pickup.amount )
 	pickup.xwidth	= w
 	pickup.width	= pickup.width + w + 16
@@ -117,7 +118,7 @@ function GM:HUDAmmoPickedUp( itemname, amount )
 	if ( self.PickupHistoryLast >= pickup.time ) then
 		pickup.time = self.PickupHistoryLast + 0.05
 	end
-	
+
 	table.insert( self.PickupHistory, pickup )
 	self.PickupHistoryLast = pickup.time
 
@@ -126,81 +127,80 @@ end
 
 function GM:HUDDrawPickupHistory()
 
-	if ( self.PickupHistory == nil ) then return end
-	
 	local x, y = ScrW() - self.PickupHistoryWide - 20, self.PickupHistoryTop
 	local tall = 0
 	local wide = 0
 
-	for k, v in pairs( self.PickupHistory ) do
-	
+	for k, v in ipairs( self.PickupHistory ) do
+
 		if ( !istable( v ) ) then
-		
+
 			Msg( tostring( v ) .."\n" )
 			PrintTable( self.PickupHistory )
 			self.PickupHistory[ k ] = nil
 			return
+
 		end
-	
+
 		if ( v.time < CurTime() ) then
-		
+
 			if ( v.y == nil ) then v.y = y end
-			
+
 			v.y = ( v.y * 5 + y ) / 6
-			
+
 			local delta = ( v.time + v.holdtime ) - CurTime()
 			delta = delta / v.holdtime
-			
+
 			local alpha = 255
 			local colordelta = math.Clamp( delta, 0.6, 0.7 )
-			
+
 			-- Fade in/out
 			if ( delta > 1 - v.fadein ) then
 				alpha = math.Clamp( ( 1.0 - delta ) * ( 255 / v.fadein ), 0, 255 )
 			elseif ( delta < v.fadeout ) then
 				alpha = math.Clamp( delta * ( 255 / v.fadeout ), 0, 255 )
 			end
-			
+
 			v.x = x + self.PickupHistoryWide - (self.PickupHistoryWide * ( alpha / 255 ) )
 
 			local rx, ry, rw, rh = math.Round( v.x - 4 ), math.Round( v.y - ( v.height / 2 ) - 4 ), math.Round( self.PickupHistoryWide + 9 ), math.Round( v.height + 8 )
 			local bordersize = 8
-			
+
 			surface.SetTexture( self.PickupHistoryCorner )
-			
+
 			surface.SetDrawColor( v.color.r, v.color.g, v.color.b, alpha )
 			surface.DrawTexturedRectRotated( rx + bordersize/2, ry + bordersize / 2, bordersize, bordersize, 0 )
 			surface.DrawTexturedRectRotated( rx + bordersize/2, ry + rh -bordersize / 2, bordersize, bordersize, 90 )
 			surface.DrawRect( rx, ry + bordersize, bordersize, rh-bordersize * 2 )
 			surface.DrawRect( rx + bordersize, ry, v.height - 4, rh )
-			
+
 			surface.SetDrawColor( 230 * colordelta, 230 * colordelta, 230 * colordelta, alpha )
 			surface.DrawRect( rx + bordersize + v.height - 4, ry, rw - ( v.height - 4 ) - bordersize * 2, rh )
 			surface.DrawTexturedRectRotated( rx + rw - bordersize / 2 , ry + rh - bordersize / 2, bordersize, bordersize, 180 )
 			surface.DrawTexturedRectRotated( rx + rw - bordersize / 2 , ry + bordersize / 2, bordersize, bordersize, 270 )
 			surface.DrawRect( rx + rw-bordersize, ry + bordersize, bordersize, rh-bordersize * 2 )
-			
+
 			draw.SimpleText( v.name, v.font, v.x + v.height + 9, v.y - ( v.height / 2 ) + 1, Color( 0, 0, 0, alpha * 0.5 ) )
-	
+
 			draw.SimpleText( v.name, v.font, v.x + v.height + 8, v.y - ( v.height / 2 ), Color( 255, 255, 255, alpha ) )
-			
+
 			if ( v.amount ) then
 
 				draw.SimpleText( v.amount, v.font, v.x + self.PickupHistoryWide + 1, v.y - ( v.height / 2 ) + 1, Color( 0, 0, 0, alpha * 0.5 ), TEXT_ALIGN_RIGHT )
 				draw.SimpleText( v.amount, v.font, v.x + self.PickupHistoryWide, v.y - ( v.height / 2 ), Color( 255, 255, 255, alpha ), TEXT_ALIGN_RIGHT )
-			
+
 			end
-			
+
 			y = y + ( v.height + 16 )
 			tall = tall + v.height + 18
 			wide = math.Max( wide, v.width + v.height + 24 )
-			
+
 			if ( alpha == 0 ) then self.PickupHistory[ k ] = nil end
-		
+
 		end
-	
+
 	end
-	
+
 	self.PickupHistoryTop = ( self.PickupHistoryTop * 5 + ( ScrH() * 0.75 - tall ) / 2 ) / 6
 	self.PickupHistoryWide = ( self.PickupHistoryWide * 5 + wide ) / 6
 


### PR DESCRIPTION
…ilable

Instead of ammo showing up as "#556_ammo" if the language string is not available, it will show up as "556 ammo". I also removed useless nil checks for a table that's clearly defined at the top and removed inconsistant trailing whitespace.

Also, Weapon.GetPrintName is a metatable method.
