### PR TITLE
Added player.GetByName

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -88,6 +88,20 @@ function player.GetBySteamID64( ID )
 
 end
 
+function player.GetByName( name )
+
+	for _, pl in pairs( player.GetAll() ) do
+
+		if ( pl:Nick() == name ) then
+			return pl
+		end
+
+	end
+
+	return false
+
+end
+
 --[[---------------------------------------------------------
 	Name: DebugInfo
 	Desc: Prints debug information for the player


### PR DESCRIPTION
This function could be helpful. There are many addons that need a function like this.
But because there is no function by gmod they have create it. And there are also such functions for the SteamID64, SteamID32, UniqueID, ...
So why not for names? :)