### PR TITLE
Fixed DImage erroring when dragging and dropping.

### DIFF
--- a/garrysmod/lua/vgui/dimage.lua
+++ b/garrysmod/lua/vgui/dimage.lua
@@ -159,7 +159,7 @@ function PANEL:Paint()
 end
 
 function PANEL:PaintAt( x, y, dw, dh )
-
+	dw, dh = dw or self:GetWide(), dh or self:GetTall()
 	self:LoadMaterial()
 
 	if ( !self.m_Material ) then return true end


### PR DESCRIPTION
DImage errors when being dragged.
```lua
local frame = vgui.Create("DFrame")
local material = "materials/spawnicons/models/weapons/w_pist_deagle_64.png"

frame:SetSize(200, 200)
frame:Center()

local image = vgui.Create("DImage", frame)
image:Dock(FILL)
image:SetImage(material)
image:SetMouseInputEnabled(true)
image:Droppable("test")

frame:MakePopup()
```

>[ERROR] lua/vgui/dimage.lua:266: bad argument #4 to 'DrawTexturedRect' (number expected, got nil)
  1. DrawTexturedRect - [C]:-1
   2. PaintAt - lua/vgui/dimage.lua:266
    3. v - lua/includes/extensions/client/panel/dragdrop.lua:269
     4. unknown - lua/includes/modules/hook.lua:84