### PR TITLE
TTT: "Fix" an issue with the Newton Launcher

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
@@ -66,6 +66,8 @@ function SWEP:SetupDataTables()
 end
 
 function SWEP:PrimaryAttack()
+   if self.IsCharging then return end
+
    self:SetNextPrimaryFire( CurTime() + self.Primary.Delay )
    self:SetNextSecondaryFire( CurTime() + self.Primary.Delay )
 


### PR DESCRIPTION
At the moment you can shoot twice if you are charging the Newton Launcher.
(So for example you charge it and don't shoot for a short time. Then you could use the primary attack and the secondar attack at the same time.)