### PR TITLE
Consistency bodygroups -> skin property

### DIFF
--- a/garrysmod/lua/autorun/properties/bodygroups.lua
+++ b/garrysmod/lua/autorun/properties/bodygroups.lua
@@ -33,12 +33,11 @@ properties.Add( "bodygroups", {
 
 	MenuOpen = function( self, option, ent, tr )
 
-		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end
-
+		local target = IsValid( ent.AttachedEntity ) and ent.AttachedEntity or ent
 		--
 		-- Get a list of bodygroups
 		--
-		local options = ent:GetBodyGroups()
+		local options = target:GetBodyGroups()
 
 		--
 		-- Add a submenu to our automatically created menu option
@@ -57,7 +56,7 @@ properties.Add( "bodygroups", {
 			--
 			if ( v.num == 2 ) then
 
-				local current = ent:GetBodygroup( v.id )
+				local current = target:GetBodygroup( v.id )
 				local opposite = 1
 				if ( current == opposite ) then opposite = 0 end
 
@@ -77,7 +76,7 @@ properties.Add( "bodygroups", {
 					local modelname = "model #" .. i
 					if ( v.submodels && v.submodels[ i-1 ] != "" ) then modelname = v.submodels[ i-1 ] end
 					local option = groups:AddOption( modelname, function() self:SetBodyGroup( ent, v.id, i-1 ) end )
-					if ( ent:GetBodygroup( v.id ) == i-1 ) then
+					if ( target:GetBodygroup( v.id ) == i-1 ) then
 						option:SetChecked( true )
 					end
 				end
@@ -111,6 +110,8 @@ properties.Add( "bodygroups", {
 		local id = net.ReadUInt( 8 )
 
 		if ( !self:Filter( ent, player ) ) then return end
+
+		ent = IsValid( ent.AttachedEntity ) and ent.AttachedEntity or ent
 
 		ent:SetBodygroup( body, id )
 


### PR DESCRIPTION
Effects have a field `ent.AttachedEntity`. When you have an effect that allows its skin to be changed through the properties menu, the actual `:SetSkin` method of the property is called with the `prop_effect`. When you have an effect that allows its bodygroup to be changed from the properties menu, the actualy `:SetBodyGroup` method of the property is called **not** with `ent` , but with `ent.AttachedEntity`. This is inconsistent and causes FPP to bug out. 

This PR fixes that inconsistency. I tested it and setting body groups still works. As for addon breakage, unless addons specifically hardcoded that shit's fucked for bodygroups, this shouldn't break anything.