### PR TITLE
Fixed material tool reload function not working

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
@@ -60,7 +60,7 @@ function TOOL:RightClick( trace )
 end
 
 -- Reload reverts the material
-function TOOL:RightClick( trace )
+function TOOL:Reload( trace )
 
 	local ent = trace.Entity
 	if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end


### PR DESCRIPTION
(it was accidentally named "TOOL:RightClick()" instead of "TOOL:Reload()", causing it to override the existing right click function)