### PR TITLE
TTT: draw weapon Help before crosshair

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -133,8 +133,11 @@ if CLIENT then
    local crosshair_size = CreateConVar("ttt_crosshair_size", "1.0", FCVAR_ARCHIVE)
    local disable_crosshair = CreateConVar("ttt_disable_crosshair", "0", FCVAR_ARCHIVE)
 
-
    function SWEP:DrawHUD()
+      if self.HUDHelp then
+         self:DrawHelp()
+      end
+
       local client = LocalPlayer()
       if disable_crosshair:GetBool() or (not IsValid(client)) then return end
 
@@ -170,10 +173,6 @@ if CLIENT then
       surface.DrawLine( x + length, y, x + gap, y )
       surface.DrawLine( x, y - length, x, y - gap )
       surface.DrawLine( x, y + length, x, y + gap )
-
-      if self.HUDHelp then
-         self:DrawHelp()
-      end
    end
 
    local GetPTranslation = LANG.GetParamTranslation


### PR DESCRIPTION
If you disable the crosshair the help from a hud wouldn't get drawn.
This shouldn't be so because you disable the crosshair, not the help.

By the way why is the crosshair drawn in SWEP:DrawHUD()?
Wouldn't it be better if it is drawn in [SWEP:DoDrawCrosshair()](http://wiki.garrysmod.com/page/WEAPON/DoDrawCrosshair)? Then developers can hide the crosshair for special equipments without overwriting the complete function.