### PR TITLE
Base: Add nil check for HUDShouldDraw Hook

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -56,7 +56,8 @@ function GM:HUDShouldDraw( name )
 
 		if ( IsValid( wep ) && wep.HUDShouldDraw != nil ) then
 
-			return wep.HUDShouldDraw( wep, name )
+			local draw = wep.HUDShouldDraw( wep, name )
+			if draw != nil then return draw end
 
 		end
 


### PR DESCRIPTION
Added a nil check to make it more consistent with the HUDShouldDraw-Hook.

At the moment:
The HUDShouldDraw-Hook doesnt't need to return something.
SWEP:HUDShouldDraw() must return something or all HUD parts are invisible.
