### PR TITLE
TTT: Fix for traitor buttons having awkward init/render behavior.

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
@@ -94,6 +94,11 @@ function ENT:TraitorUse(ply)
    return true
 end
 
+-- Fix for traitor buttons having awkward init/render behavior, in the event that a map has been optimized with area portals.
+function ENT:UpdateTransmitState()
+   return TRANSMIT_ALWAYS
+end
+
 local function TraitorUseCmd(ply, cmd, args)
    if #args != 1 then return end
 


### PR DESCRIPTION
TL;DR: Highly optimized maps can cause traitor buttons to fail to initialize clientside at the start of a round, resulting in particularly awkward and probably unintended impositions for traitors.

The issue, in detail, is that due to the cleanup at the beginning of a round, traitor buttons can fail to initialize clientside for players that have not visited the area in which said traitor button is found, if said area is sealed with multiple area portals or otherwise has separate sealed areas between it and the client and/or has visleafs that further restrict rendering - particularly if hints have been used.

This results in the need for traitors to behave quite predictably(and sometimes putting themselves at undue risk) if they are to use traitor buttons that are caught up in this circumstance, annoyingly more-so because it is an issue that persists for every round unless the traitor lucks out and is able to sneakily get to a position that triggers the entity's clientside init, before making contact with other players.

A simple fix really, inspired by looking at the detective beacon entity, of all things - which I am working to try and fix also :P