### PR TITLE
TTT: Remove fingerprint functionality from beacons

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -55,7 +55,6 @@ function ENT:UseOverride(activator)
 
       if IsValid(wep) then
          wep.fingerprints = wep.fingerprints or {}
-         -- Fix c-side error which hangs server on beacon pickup, giving only an ambiguous blue "[ERROR]" message in console.
          table.Add(wep.fingerprints, #wep.fingerprints + 1, prints)
       end
    end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -55,8 +55,7 @@ function ENT:UseOverride(activator)
 
       if IsValid(wep) then
          wep.fingerprints = wep.fingerprints or {}
-         -- Fix error which hangs server on beacon pickup
-         table.Add(wep.fingerprints, #wep.fingerprints + 1, prints)
+         table.Add(wep.fingerprints, prints)
       end
    end
 end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -50,13 +50,7 @@ function ENT:UseOverride(activator)
          wep = activator:Give("weapon_ttt_beacon")
       end
 
-      local prints = self.fingerprints or {}
       self:Remove()
-
-      if IsValid(wep) then
-         wep.fingerprints = wep.fingerprints or {}
-         table.Add(wep.fingerprints, prints)
-      end
    end
 end
 

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -55,6 +55,7 @@ function ENT:UseOverride(activator)
 
       if IsValid(wep) then
          wep.fingerprints = wep.fingerprints or {}
+         -- Fix error which hangs server on beacon pickup
          table.Add(wep.fingerprints, #wep.fingerprints + 1, prints)
       end
    end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -55,7 +55,8 @@ function ENT:UseOverride(activator)
 
       if IsValid(wep) then
          wep.fingerprints = wep.fingerprints or {}
-         table.Add(wep.fingerprints, prints)
+         -- Fix c-side error which hangs server on beacon pickup, giving only an ambiguous blue "[ERROR]" message in console.
+         table.Add(wep.fingerprints, #wep.fingerprints + 1, prints)
       end
    end
 end

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -96,8 +96,6 @@ function SWEP:BeaconDrop()
          beacon:SetOwner(ply)
          beacon:Spawn()
 
-         beacon.fingerprints = self.fingerprints
-
          beacon:PointAtEntity(ply)
          
          local ang = beacon:GetAngles()
@@ -147,8 +145,6 @@ function SWEP:BeaconStick()
                beacon:SetAngles(ang)
                beacon:SetOwner(ply)
                beacon:Spawn()
-
-               beacon.fingerprints = self.fingerprints
 
                local phys = beacon:GetPhysicsObject()
                if IsValid(phys) then

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -108,7 +108,8 @@ function table.Add( dest, source )
 	if ( type( dest ) != "table" ) then dest = {} end
 
 	for k, v in pairs( source ) do
-		table.insert( dest, v )
+		--table.insert( dest, v )
+		dest[k] = v -- this is safe, i've tested to make sure that pairs() returns the apropriate value type for k, in the case of both number and string indexes, even tables as indicies...
 	end
 
 	return dest

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -108,8 +108,7 @@ function table.Add( dest, source )
 	if ( type( dest ) != "table" ) then dest = {} end
 
 	for k, v in pairs( source ) do
-		--table.insert( dest, v )
-		dest[k] = v -- this is safe, i've tested to make sure that pairs() returns the apropriate value type for k, in the case of both number and string indexes, even tables as indicies...
+		table.insert( dest, v )
 	end
 
 	return dest


### PR DESCRIPTION
~snipped previous description.

Actual issue stems from planted beacon entity receiving reference to beacon weapon's fingerprints table, instead of a new/cached table of it's own - entity attempts to merge the weapon's fingerprints table, with itself, instead of merging it's own fingerprints with that of the weapon(?)

gamemodes/terrortown/entites/weapons/weapon_ttt_beacon.lua @ lines 99 & 151

Latest update: Can't concoct a viable work around for beacons to utilize fingerprints, recommend removing fingerprint functionality from beacons.