### PR TITLE
TTT: Added hooks to allow easier modification of corpse id/search behavior.

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -36,6 +36,12 @@ end
 -- If detective mode, announce when someone's body is found
 local bodyfound = CreateConVar("ttt_announce_body_found", "1")
 
+-- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+function GM:TTTInterruptCorpseIdentify(identifier,corpse,corpse_is_traitor)
+   -- return true to interrupt corpse identification
+   return false
+end
+
 local function IdentifyBody(ply, rag)
    if not ply:IsTerror() then return end
 
@@ -48,6 +54,11 @@ local function IdentifyBody(ply, rag)
    local finder = ply:Nick()
    local nick = CORPSE.GetPlayerNick(rag, "")
    local traitor = (rag.was_role == ROLE_TRAITOR)
+   
+   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse identification.
+   if hook.Run("TTTInterruptCorpseIdentify", ply, rag, traitor) then
+      return
+   end
 
    -- Announce body
    if bodyfound:GetBool() and not CORPSE.GetFound(rag, false) then
@@ -169,6 +180,12 @@ local function bitsRequired(num)
    return bits
 end
 
+-- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+function GM:TTTInterruptCorpseSearch(identifier,corpse,corpse_is_traitor)
+   -- return true to interrupt corpse search
+   return false
+end
+
 -- Send a usermessage to client containing search results
 function CORPSE.ShowSearch(ply, rag, covert, long_range)
    if not IsValid(ply) or not IsValid(rag) then return end
@@ -189,6 +206,11 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
    local words = rag.last_words or ""
    local hshot = rag.was_headshot or false
    local dtime = rag.time or 0
+   
+   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+   if hook.Run("TTTInterruptCorpseSearch", ply, rag, traitor) then
+      return
+   end
 
    local owner = player.GetBySteamID(rag.sid)
    owner = IsValid(owner) and owner:EntIndex() or -1

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -36,7 +36,6 @@ end
 -- If detective mode, announce when someone's body is found
 local bodyfound = CreateConVar("ttt_announce_body_found", "1")
 
--- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
 function GM:TTTCanIdentifyCorpse(identifier, corpse)
    -- return true to allow corpse identification, false to disallow
    return true
@@ -51,7 +50,6 @@ local function IdentifyBody(ply, rag)
       return
    end
    
-   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse identification.
    if not hook.Run("TTTCanIdentifyCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
       return
    end
@@ -180,7 +178,6 @@ local function bitsRequired(num)
    return bits
 end
 
--- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
 function GM:TTTCanSearchCorpse(searcher, corpse, corpse_is_traitor)
    -- return true to allow corpse search, false to disallow.
    return true
@@ -195,7 +192,6 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
       return
    end
    
-   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
    if not hook.Run("TTTCanSearchCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
       return
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -457,6 +457,8 @@ function CORPSE.Create(ply, attacker, dmginfo)
       local efn = ply.effect_fn
       timer.Simple(0, function() efn(rag) end)
    end
+   
+   hook.Run("TTTOnCorpseCreated", rag)
 
    return rag -- we'll be speccing this
 end


### PR DESCRIPTION
I would like to propose these hook additions which would allow modders (if not just myself, others also) to easily create weapons and entities and other conditions which interrupt the ability for players to identify/search a corpse - without making changes to the corpse.lua file.
I am happy to privately share examples where these are sorely needed, for at least my own purposes - but let your imagination run wild a bit yourself ;)

**_"TTTCanIdentifyCorpse"_ (ply, corpse, corpse_was_traitor)**
Called to determine if a player can identify the corpse they are trying to inspect; return true to allow, false to disallow.

**_"TTTCanSearchCorpse"_ (ply, corpse, corpse_was_traitor)**
Called to determine if a player can view the search interface for the corpse they are trying to inspect; return true to allow, false to disallow.

**_"TTTOnCorpseCreated"_ (corpse)**
Called after a player has been killed and their corpse has been created and spawned with all essential variables set.

Ideally, this would be something for traitors to benefit from only( and in fair ways pertaining to the use of equipment items ), though it could be abused in ways that really ruin the gameplay - that said, if someone were determined enough to do that, they would almost certainly have done so already with or without such hooks.