### PR TITLE
TTT: Paint Background of Score Panel

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -136,7 +136,6 @@ function CLSCORE:BuildScorePanel(dpanel)
    dlist:SetSize(w, h)
    dlist:SetSortable(true)
    dlist:SetMultiSelect(false)
-   dlist:SetPaintBackground(false)
 
    local colnames = {"", "col_player", "col_role", "col_kills1", "col_kills2", "col_points", "col_team", "col_total"}
    for k, name in pairs(colnames) do


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/7966992/19829800/315f748e-9deb-11e6-83c9-fd56e2c2518e.png)

After:
![image](https://cloud.githubusercontent.com/assets/7966992/19829803/3506ceb6-9deb-11e6-8546-4f7b3ba8b191.png)

To make it like the [Event Log Panel](https://github.com/garrynewman/garrysmod/blob/master/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua#L108-L112).