### PR TITLE
TTT: Fix mistakes in corpse.lua relating to previous commit.

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -192,7 +192,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
       return
    end
    
-   if not hook.Run("TTTCanSearchCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
+   if not hook.Run("TTTCanSearchCorpse", ply, rag, covert, long_range, (rag.was_role == ROLE_TRAITOR)) then
       return
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -36,6 +36,12 @@ end
 -- If detective mode, announce when someone's body is found
 local bodyfound = CreateConVar("ttt_announce_body_found", "1")
 
+-- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+function GM:TTTInterruptCorpseIdentify(identifier,corpse,corpse_is_traitor)
+   -- return true to interrupt corpse identification
+   return false
+end
+
 local function IdentifyBody(ply, rag)
    if not ply:IsTerror() then return end
 
@@ -48,6 +54,11 @@ local function IdentifyBody(ply, rag)
    local finder = ply:Nick()
    local nick = CORPSE.GetPlayerNick(rag, "")
    local traitor = (rag.was_role == ROLE_TRAITOR)
+   
+   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse identification.
+   if hook.Run("TTTInterruptCorpseIdentify", ply, rag, traitor) then
+      return
+   end
 
    -- Announce body
    if bodyfound:GetBool() and not CORPSE.GetFound(rag, false) then
@@ -169,6 +180,12 @@ local function bitsRequired(num)
    return bits
 end
 
+-- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+function GM:TTTInterruptCorpseSearch(identifier,corpse,corpse_is_traitor)
+   -- return true to interrupt corpse search
+   return false
+end
+
 -- Send a usermessage to client containing search results
 function CORPSE.ShowSearch(ply, rag, covert, long_range)
    if not IsValid(ply) or not IsValid(rag) then return end
@@ -189,6 +206,11 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
    local words = rag.last_words or ""
    local hshot = rag.was_headshot or false
    local dtime = rag.time or 0
+   
+   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
+   if hook.Run("TTTInterruptCorpseSearch", ply, rag, traitor) then
+      return
+   end
 
    local owner = player.GetBySteamID(rag.sid)
    owner = IsValid(owner) and owner:EntIndex() or -1

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -36,7 +36,6 @@ end
 -- If detective mode, announce when someone's body is found
 local bodyfound = CreateConVar("ttt_announce_body_found", "1")
 
--- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
 function GM:TTTCanIdentifyCorpse(identifier, corpse)
    -- return true to allow corpse identification, false to disallow
    return true
@@ -51,7 +50,6 @@ local function IdentifyBody(ply, rag)
       return
    end
    
-   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse identification.
    if not hook.Run("TTTCanIdentifyCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
       return
    end
@@ -180,7 +178,6 @@ local function bitsRequired(num)
    return bits
 end
 
--- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
 function GM:TTTCanSearchCorpse(searcher, corpse, corpse_is_traitor)
    -- return true to allow corpse search, false to disallow.
    return true
@@ -195,7 +192,6 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
       return
    end
    
-   -- opportunity for addons to introduce ways for traitors(ideally) to interrupt corpse searching.
    if not hook.Run("TTTCanSearchCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
       return
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -458,7 +458,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
       timer.Simple(0, function() efn(rag) end)
    end
    
-   hook.Run("TTTOnCorpseCreated", rag)
+   hook.Run("TTTOnCorpseCreated", rag, ply)
 
    return rag -- we'll be speccing this
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -178,7 +178,7 @@ local function bitsRequired(num)
    return bits
 end
 
-function GM:TTTCanSearchCorpse(searcher, corpse, corpse_is_traitor)
+function GM:TTTCanSearchCorpse(searcher, corpse, covert, long_range, corpse_is_traitor)
    -- return true to allow corpse search, false to disallow.
    return true
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -457,6 +457,8 @@ function CORPSE.Create(ply, attacker, dmginfo)
       local efn = ply.effect_fn
       timer.Simple(0, function() efn(rag) end)
    end
+   
+   hook.Run("TTTOnCorpseCreated", rag)
 
    return rag -- we'll be speccing this
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -36,7 +36,7 @@ end
 -- If detective mode, announce when someone's body is found
 local bodyfound = CreateConVar("ttt_announce_body_found", "1")
 
-function GM:TTTCanIdentifyCorpse(identifier, corpse)
+function GM:TTTCanIdentifyCorpse(identifier, corpse, corpse_is_traitor)
    -- return true to allow corpse identification, false to disallow
    return true
 end


### PR DESCRIPTION
This fixes several mistakes/omissions regarding the last commit I made for this file, which introduced 3 new hooks to allow modders to more-easily modify the default corpse id/search behavior.

**_"TTTCanIdentifyCorpse"_ (ply, corpse, corpse_was_traitor)**
Called to determine if a player can identify the corpse they are trying to inspect; return true to allow, false to disallow.

**_"TTTCanSearchCorpse"_ (ply, corpse, covert, long_range, corpse_was_traitor)**
Called to determine if a player can view the search interface for the corpse they are trying to inspect; return true to allow, false to disallow.

**_"TTTOnCorpseCreated"_ (corpse, corpse_player)**
Called after a player has been killed and their corpse has been created and spawned with all essential variables set.