### PR TITLE
TTT: Added some useful things

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -126,18 +126,16 @@ if SERVER then
    end
 
    local function TestHat(ply, cmd, args)
-      if cvars.Bool("sv_cheats", 0) then
-         local hat = ents.Create("ttt_hat_deerstalker")
+      local hat = ents.Create("ttt_hat_deerstalker")
 
-         hat:SetPos(ply:GetPos() + Vector(0,0,70))
-         hat:SetAngles(ply:GetAngles())
+      hat:SetPos(ply:GetPos() + Vector(0,0,70))
+      hat:SetAngles(ply:GetAngles())
 
-         hat:SetParent(ply)
+      hat:SetParent(ply)
 
-         ply.hat = hat
+      ply.hat = hat
 
-         hat:Spawn()
-      end
+      hat:Spawn()
    end
-   concommand.Add("ttt_debug_testhat", TestHat)
+   concommand.Add("ttt_debug_testhat", TestHat, nil, nil, FCVAR_CHEAT)
 end

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
@@ -71,11 +71,24 @@ function ENT:AcceptInput(name, activator)
    end
 end
 
+function GAMEMODE:TTTCanUseTraitorButton(ent, ply)
+   -- Can be used to prevent players from using this button.
+   -- Return a boolean and a message that can shows up if you can't use the button.
+   -- Example: return false, "Not allowed".
+   return true
+end
+
 function ENT:TraitorUse(ply)
    if not (IsValid(ply) and ply:IsActiveTraitor()) then return false end
    if not self:IsUsable() then return false end
 
    if self:GetPos():Distance(ply:GetPos()) > self:GetUsableRange() then return false end
+
+   local use, message = hook.Run("TTTCanUseTraitorButton", self, ply)
+   if not use then
+      if message then TraitorMsg(ply, message) end
+      return false
+   end
 
    net.Start("TTT_ConfirmUseTButton") net.Send(ply)
 
@@ -90,7 +103,7 @@ function ENT:TraitorUse(ply)
       self:SetNextUseTime(CurTime() + self:GetDelay())
    end
 
-   hook.Call("TTTTraitorButtonActivated", GAMEMODE, self, ply)
+   hook.Run("TTTTraitorButtonActivated", self, ply)
    return true
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -233,7 +233,7 @@ local function InfoPaint(client)
    ShadowedText(tostring(health), "HealthAmmo", bar_width, health_y, COLOR_WHITE, TEXT_ALIGN_RIGHT, TEXT_ALIGN_RIGHT)
 
    if ttt_health_label:GetBool() then
-      local health_status = util.HealthToString(health)
+      local health_status = util.HealthToString(health, client:GetMaxHealth())
       draw.SimpleText(L[health_status], "TabLarge", x + margin*2, health_y + bar_height/2, COLOR_WHITE, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -105,7 +105,7 @@ local function DrawPropSpecLabels(client)
             scrpos = nil
          end
       else
-         local _, healthcolor = util.HealthToString(ply:Health())
+         local _, healthcolor = util.HealthToString(ply:Health(), ply:GetMaxHealth())
          surface.SetTextColor(clr(healthcolor))
 
          scrpos = ply:EyePos()
@@ -190,7 +190,7 @@ function GM:HUDDrawTargetID()
       local _ -- Stop global clutter
       -- in minimalist targetID, colour nick with health level
       if minimal then
-         _, color = util.HealthToString(ent:Health())
+         _, color = util.HealthToString(ent:Health(), ent:GetMaxHealth())
       end
 
       if client:IsTraitor() and GAMEMODE.round_state == ROUND_ACTIVE then
@@ -265,7 +265,7 @@ function GM:HUDDrawTargetID()
    -- Draw subtitle: health or type
    local clr = rag_color
    if ent:IsPlayer() then
-      text, clr = util.HealthToString(ent:Health())
+      text, clr = util.HealthToString(ent:Health(), ent:GetMaxHealth())
 
       -- HealthToString returns a string id, need to look it up
       text = L[text]

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -767,7 +767,7 @@ function EndRound(type)
 
    -- server plugins might want to start a map vote here or something
    -- these hooks are not used by TTT internally
-   hook.Call("TTTEndRound", GAMEMODE, type)
+   hook.Call("TTTEndRound", GAMEMODE, type, GAMEMODE.MapWin and true or false)
 
    ents.TTT.TriggerRoundStateOutputs(ROUND_POST, type)
 end
@@ -781,9 +781,7 @@ function GM:TTTCheckForWin()
    if ttt_dbgwin:GetBool() then return WIN_NONE end
 
    if GAMEMODE.MapWin == WIN_TRAITOR or GAMEMODE.MapWin == WIN_INNOCENT then
-      local mw = GAMEMODE.MapWin
-      GAMEMODE.MapWin = WIN_NONE
-      return mw
+      return GAMEMODE.MapWin
    end
 
    local traitor_alive = false

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -767,7 +767,7 @@ function EndRound(type)
 
    -- server plugins might want to start a map vote here or something
    -- these hooks are not used by TTT internally
-   hook.Call("TTTEndRound", GAMEMODE, type, GAMEMODE.MapWin and true or false)
+   hook.Call("TTTEndRound", GAMEMODE, type)
 
    ents.TTT.TriggerRoundStateOutputs(ROUND_POST, type)
 end
@@ -781,7 +781,9 @@ function GM:TTTCheckForWin()
    if ttt_dbgwin:GetBool() then return WIN_NONE end
 
    if GAMEMODE.MapWin == WIN_TRAITOR or GAMEMODE.MapWin == WIN_INNOCENT then
-      return GAMEMODE.MapWin
+      local mw = GAMEMODE.MapWin
+      GAMEMODE.MapWin = WIN_NONE
+      return mw
    end
 
    local traitor_alive = false

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -33,8 +33,13 @@ local function IsDebug() return config.debug:GetBool() end
 
 local math = math
 
+cvars.AddChangeCallback("ttt_karma_max", function(cvar, old, new)
+   SetGlobalInt("ttt_karma_max", new)
+end)
+
 function KARMA.InitState()
    SetGlobalBool("ttt_karma", config.enabled:GetBool())
+   SetGlobalInt("ttt_karma_max", config.max:GetFloat())
 end
 
 function KARMA.IsEnabled()

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -127,38 +127,32 @@ end
 concommand.Add("_ttt_request_rolelist", request_rolelist)
 
 local function force_terror(ply)
-   if cvars.Bool("sv_cheats") then
-      ply:SetRole(ROLE_INNOCENT)
-      ply:UnSpectate()
-      ply:SetTeam(TEAM_TERROR)
+   ply:SetRole(ROLE_INNOCENT)
+   ply:UnSpectate()
+   ply:SetTeam(TEAM_TERROR)
 
-      ply:StripAll()
+   ply:StripAll()
 
-      ply:Spawn()
-      ply:PrintMessage(HUD_PRINTTALK, "You are now on the terrorist team.")
+   ply:Spawn()
+   ply:PrintMessage(HUD_PRINTTALK, "You are now on the terrorist team.")
 
-      SendFullStateUpdate()
-   end
+   SendFullStateUpdate()
 end
-concommand.Add("ttt_force_terror", force_terror)
+concommand.Add("ttt_force_terror", force_terror, nil, nil, FCVAR_CHEAT)
 
 local function force_traitor(ply)
-   if cvars.Bool("sv_cheats") then
-      ply:SetRole(ROLE_TRAITOR)
+   ply:SetRole(ROLE_TRAITOR)
 
-      SendFullStateUpdate()
-   end
+   SendFullStateUpdate()
 end
-concommand.Add("ttt_force_traitor", force_traitor)
+concommand.Add("ttt_force_traitor", force_traitor, nil, nil, FCVAR_CHEAT)
 
 local function force_detective(ply)
-   if cvars.Bool("sv_cheats") then
-      ply:SetRole(ROLE_DETECTIVE)
+   ply:SetRole(ROLE_DETECTIVE)
 
-      SendFullStateUpdate()
-   end
+   SendFullStateUpdate()
 end
-concommand.Add("ttt_force_detective", force_detective)
+concommand.Add("ttt_force_detective", force_detective, nil, nil, FCVAR_CHEAT)
 
 
 local function force_spectate(ply, cmd, arg)

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -301,21 +301,23 @@ end
 
 if CLIENT then
    local healthcolors = {
-      healthy = Color(0,255,0,255),
-      hurt    = Color(170,230,10,255),
-      wounded = Color(230,215,10,255),
-      badwound= Color(255,140,0,255),
-      death   = Color(255,0,0,255)
+      healthy = Color(0, 255, 0, 255),
+      hurt    = Color(170, 230, 10, 255),
+      wounded = Color(230, 215, 10, 255),
+      badwound= Color(255, 140, 0, 255),
+      death   = Color(255, 0, 0, 255)
    };
 
-   function util.HealthToString(health)
-      if health > 90 then
+   function util.HealthToString(health, maxhealth)
+      maxhealth = maxhealth or 100
+
+      if health > maxhealth * 0.9 then
          return "hp_healthy", healthcolors.healthy
-      elseif health > 70 then
+      elseif health > maxhealth * 0.7 then
          return "hp_hurt", healthcolors.hurt
-      elseif health > 45 then
+      elseif health > maxhealth * 0.45 then
          return "hp_wounded", healthcolors.wounded
-      elseif health > 20 then
+      elseif health > maxhealth * 0.2 then
          return "hp_badwnd", healthcolors.badwound
       else
          return "hp_death", healthcolors.death
@@ -323,21 +325,23 @@ if CLIENT then
    end
 
    local karmacolors = {
-      max  = Color(255,255,255,255),
-      high = Color(255,240,135,255),
-      med  = Color(245,220,60,255),
-      low  = Color(255,180,0,255),
-      min  = Color(255,130,0,255),
+      max  = Color(255, 255, 255, 255),
+      high = Color(255, 240, 135, 255),
+      med  = Color(245, 220, 60, 255),
+      low  = Color(255, 180, 0, 255),
+      min  = Color(255, 130, 0, 255),
    };
 
    function util.KarmaToString(karma)
-      if karma > 890 then
+      local maxkarma = GetGlobalInt("ttt_karma_max", 1000)
+
+      if karma > maxkarma * 0.89 then
          return "karma_max", karmacolors.max
-      elseif karma > 800 then
+      elseif karma > maxkarma * 0.8 then
          return "karma_high", karmacolors.high
-      elseif karma > 650 then
+      elseif karma > maxkarma * 0.65 then
          return "karma_med", karmacolors.med
-      elseif karma > 500 then
+      elseif karma > maxkarma * 0.5 then
          return "karma_low", karmacolors.low
       else
          return "karma_min", karmacolors.min

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -308,4 +308,4 @@ function PANEL:DoRightClick()
    menu:Open()
 end
 
-vgui.Register( "TTTScorePlayerRow", PANEL, "Button" )
+vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -425,11 +425,17 @@ local function OrderEquipment(ply, cmd, args)
 end
 concommand.Add("ttt_order_equipment", OrderEquipment)
 
+function GM:TTTCanToggleDisguiser(ply, state)
+   -- Can be used to prevent players from using this button.
+   return true
+end
+
 local function SetDisguise(ply, cmd, args)
    if not IsValid(ply) or not ply:IsActiveTraitor() then return end
 
    if ply:HasEquipmentItem(EQUIP_DISGUISE) then
       local state = #args == 1 and tobool(args[1])
+      if not hook.Run("TTTCanToggleDisguiser", ply, state) then return end
 
       ply:SetNWBool("disguised", state)
       LANG.Msg(ply, state and "disg_turned_on" or "disg_turned_off")
@@ -438,11 +444,11 @@ end
 concommand.Add("ttt_set_disguise", SetDisguise)
 
 local function CheatCredits(ply)
-   if cvars.Bool("sv_cheats", false) and IsValid(ply) then
+   if IsValid(ply) then
       ply:AddCredits(10)
    end
 end
-concommand.Add("ttt_cheat_credits", CheatCredits)
+concommand.Add("ttt_cheat_credits", CheatCredits, nil, nil, FCVAR_CHEAT)
 
 local function TransferCredits(ply, cmd, args)
    if (not IsValid(ply)) or (not ply:IsActiveSpecial()) then return end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -425,9 +425,9 @@ local function OrderEquipment(ply, cmd, args)
 end
 concommand.Add("ttt_order_equipment", OrderEquipment)
 
-function GM:TTTCanToggleDisguiser(ply, state)
+function GM:TTTToggleDisguiser(ply, state)
    -- Can be used to prevent players from using this button.
-   return true
+   -- return false to prevent it.
 end
 
 local function SetDisguise(ply, cmd, args)
@@ -435,7 +435,7 @@ local function SetDisguise(ply, cmd, args)
 
    if ply:HasEquipmentItem(EQUIP_DISGUISE) then
       local state = #args == 1 and tobool(args[1])
-      if not hook.Run("TTTCanToggleDisguiser", ply, state) then return end
+      if not hook.Run("TTTToggleDisguiser", ply, state) == false then return end
 
       ply:SetNWBool("disguised", state)
       LANG.Msg(ply, state and "disg_turned_on" or "disg_turned_off")


### PR DESCRIPTION
A small overview of the changes and some informations about them:
- I changed the ConCommand that requires `sv_cheats 1`. Now the Flag `FCVAR_CHEAT` is used because this is a bit better because it tells the client that the command requires `sv_cheats 1`.
- Added a hook to prevent using a traitor button. (Could be useful for some addons.)
Hook Name: `TTTCanUseTraitorButton`
Arguments: `ttt_traitor_button-Entity; Player that used the Button` (`self, ply`)
Return: Return false to prevent using it. You can also return a message that is shown up if you aren't allowed to use the button. (Example: `return false, "Not allowed."`)
- Added a second argument to `TTTEndRound` (Serverside only) that gives the information if the round end was triggered by the map.
(Could be useful for some addons.)
- Added a hook that is triggered when a user toggles his disguiser.
Hook Name: `TTTCanToggleDisguiser`
Arguments: `player that toggles the disguiser; boolean that tells to which state the disguiser would be changed.`
Return: Return false to prevent toggling the disguiser.
(This is very useful for addons like the [PowerRound-Addon](https://scriptfodder.com/scripts/view/401/) or the [TTTDamagelog-Addon](https://github.com/Tommy228/TTTDamagelogs/blob/master/lua/damagelogs/damagelog_events/misc.lua#L22-L29).)