### PR TITLE
Fix Anti-AFK Exploit

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -370,9 +370,9 @@ function CheckIdle()
 
          timer.Simple(0.3, function()
                               RunConsoleCommand("ttt_spectator_mode", 1) -- If they want to bypass it now they still can but this way they still get fspecced
-                              net.Start("ttt_spectate")
-                                net.WriteBool(true)
-                              net.SendToServer()
+                               net.Start("ttt_spectate")
+                                 net.WriteInt(1,2)
+                               net.SendToServer()
                               RunConsoleCommand("ttt_cl_idlepopup")
                            end)
       elseif CurTime() > (idle.t + (idle_limit / 2)) then

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -52,7 +52,7 @@ function GM:Initialize()
 
    self.BaseClass:Initialize()
 
-   net.Start("ttt_spectate")
+   net.Start("TTT_Spectate")
      net.WriteInt(math.Clamp(GetConVar("ttt_spectator_mode"):GetInt(),0,1),2)
    net.SendToServer()
 end
@@ -370,7 +370,7 @@ function CheckIdle()
 
          timer.Simple(0.3, function()
                               RunConsoleCommand("ttt_spectator_mode", 1) -- If they want to bypass it now they still can but this way they still get fspecced
-                               net.Start("ttt_spectate")
+                               net.Start("TTT_Spectate")
                                  net.WriteInt(1,2)
                                net.SendToServer()
                               RunConsoleCommand("ttt_cl_idlepopup")

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -52,7 +52,9 @@ function GM:Initialize()
 
    self.BaseClass:Initialize()
 
-   RunConsoleCommand("ttt_spectate", GetConVar("ttt_spectator_mode"):GetInt())
+   net.Start("ttt_spectate")
+     net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool())
+   net.SendToServer()
 end
 
 function GM:InitPostEntity()
@@ -367,7 +369,10 @@ function CheckIdle()
          RunConsoleCommand("say", "(AUTOMATED MESSAGE) I have been moved to the Spectator team because I was idle/AFK.")
 
          timer.Simple(0.3, function()
-                              RunConsoleCommand("toggle","ttt_spectator_mode", 1)
+                              RunConsoleCommand("ttt_spectator_mode", 1) -- If they want to bypass it now they still can but this way they still get fspecced
+                              net.Start("ttt_spectate")
+                                net.WriteBool(true)
+                              net.SendToServer()
                               RunConsoleCommand("ttt_cl_idlepopup")
                            end)
       elseif CurTime() > (idle.t + (idle_limit / 2)) then

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -53,7 +53,7 @@ function GM:Initialize()
    self.BaseClass:Initialize()
 
    net.Start("ttt_spectate")
-     net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool())
+     net.WriteInt(math.Clamp(GetConVar("ttt_spectator_mode"):GetInt(),0,1),2)
    net.SendToServer()
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -367,7 +367,7 @@ function CheckIdle()
          RunConsoleCommand("say", "(AUTOMATED MESSAGE) I have been moved to the Spectator team because I was idle/AFK.")
 
          timer.Simple(0.3, function()
-                              RunConsoleCommand("ttt_spectator_mode", 1)
+                              RunConsoleCommand("toggle","ttt_spectator_mode", 1)
                               RunConsoleCommand("ttt_cl_idlepopup")
                            end)
       elseif CurTime() > (idle.t + (idle_limit / 2)) then

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -154,7 +154,7 @@ util.AddNetworkString("TTT_ShowPrints")
 util.AddNetworkString("TTT_ScanResult")
 util.AddNetworkString("TTT_FlareScorch")
 util.AddNetworkString("TTT_Radar")
-
+util.AddNetworkString("TTT_Spectate")
 ---- Round mechanics
 function GM:Initialize()
    MsgN("Trouble In Terrorist Town gamemode initializing...")

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -161,9 +161,9 @@ end
 concommand.Add("ttt_force_detective", force_detective)
 
 
-local function force_spectate(ply, cmd, arg)
+local function force_spectate(ply, arg)
    if IsValid(ply) then
-      if #arg == 1 and tonumber(arg[1]) == 0 then
+      if !arg then
          ply:SetForceSpec(false)
       else
          if not ply:IsSpec() then
@@ -179,6 +179,7 @@ local function force_spectate(ply, cmd, arg)
       end
    end
 end
-concommand.Add("ttt_spectate", force_spectate)
-
+net.Receive("ttt_spectate", function(l,pl)
+   force_spectate(pl,net.readBool())
+end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -179,6 +179,7 @@ local function force_spectate(ply, arg)
       end
    end
 end
+concommand.Add("ttt_spectate", force_spectate)
 net.Receive("ttt_spectate", function(l,pl)
    force_spectate(pl,net.ReadBool())
 end)

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -181,6 +181,6 @@ local function force_spectate(ply, cmd, arg)
 end
 concommand.Add("ttt_spectate", force_spectate)
 net.Receive("ttt_spectate", function(l, pl)
-   force_spectate(pl, null, net.ReadInt(1))
+   force_spectate(pl, null, net.ReadInt(2))
 end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -1,4 +1,4 @@
-
+util.AddNetworkString("ttt_spectate")
 function GetTraitors()
    local trs = {}
    for k,v in ipairs(player.GetAll()) do
@@ -180,7 +180,7 @@ local function force_spectate(ply, arg)
    end
 end
 concommand.Add("ttt_spectate", force_spectate)
-net.Receive("ttt_spectate", function(l,pl)
-   force_spectate(pl,net.ReadBool())
+net.Receive("ttt_spectate", function(l, pl)
+   force_spectate(pl, net.ReadBool())
 end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -1,4 +1,3 @@
-util.AddNetworkString("ttt_spectate")
 function GetTraitors()
    local trs = {}
    for k,v in ipairs(player.GetAll()) do
@@ -163,7 +162,7 @@ concommand.Add("ttt_force_detective", force_detective)
 
 local function force_spectate(ply, cmd, arg)
    if IsValid(ply) then
-      if arg == 0 then
+      if #arg == 1 and tonumber(arg[1]) == 0 then
          ply:SetForceSpec(false)
       else
          if not ply:IsSpec() then
@@ -180,7 +179,7 @@ local function force_spectate(ply, cmd, arg)
    end
 end
 concommand.Add("ttt_spectate", force_spectate)
-net.Receive("ttt_spectate", function(l, pl)
-   force_spectate(pl, null, net.ReadInt(2))
+net.Receive("TTT_Spectate", function(l, pl)
+   force_spectate(pl, nil, {net.ReadInt(2)})
 end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -161,9 +161,9 @@ end
 concommand.Add("ttt_force_detective", force_detective)
 
 
-local function force_spectate(ply, arg)
+local function force_spectate(ply, cmd, arg)
    if IsValid(ply) then
-      if !arg then
+      if arg == 0 then
          ply:SetForceSpec(false)
       else
          if not ply:IsSpec() then
@@ -181,6 +181,6 @@ local function force_spectate(ply, arg)
 end
 concommand.Add("ttt_spectate", force_spectate)
 net.Receive("ttt_spectate", function(l, pl)
-   force_spectate(pl, net.ReadBool())
+   force_spectate(pl, null, net.ReadInt(1))
 end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -180,6 +180,6 @@ local function force_spectate(ply, arg)
    end
 end
 net.Receive("ttt_spectate", function(l,pl)
-   force_spectate(pl,net.readBool())
+   force_spectate(pl,net.ReadBool())
 end)
 


### PR DESCRIPTION
Fixes an exploit to bypass the AFK switcher. The exploit is to use the alias console command to overwrite the "ttt_spectator_mode" console command. This fixes it because toggle treats ttt_spectator_mode as a ConVar, which it is, whereas just calling ttt_spectator_mode 1 treats it as a concommand, and the alias exploit overwrites the concommand (I don't actually know if this is how this works, I don't know the engine of the game, I'm just making a conjecture of why this works.) If needed I can provide the exploit but I'm sure you can find it out if you're on Github.