### PR TITLE
Fix Anti-AFK Exploit

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -53,7 +53,7 @@ function GM:Initialize()
    self.BaseClass:Initialize()
 
    net.Start("TTT_Spectate")
-     net.WriteBool(GetConVar("ttt_spectator_mode")):GetBool()
+     net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool())
    net.SendToServer()
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -53,7 +53,7 @@ function GM:Initialize()
    self.BaseClass:Initialize()
 
    net.Start("TTT_Spectate")
-     net.WriteInt(math.Clamp(GetConVar("ttt_spectator_mode"):GetInt(),0,1),2)
+     net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool()
    net.SendToServer()
 end
 
@@ -369,9 +369,9 @@ function CheckIdle()
          RunConsoleCommand("say", "(AUTOMATED MESSAGE) I have been moved to the Spectator team because I was idle/AFK.")
 
          timer.Simple(0.3, function()
-                              RunConsoleCommand("ttt_spectator_mode", 1) -- If they want to bypass it now they still can but this way they still get fspecced
+                              RunConsoleCommand("ttt_spectator_mode", 1)
                                net.Start("TTT_Spectate")
-                                 net.WriteInt(1,2)
+                                 net.WriteBool(true)
                                net.SendToServer()
                               RunConsoleCommand("ttt_cl_idlepopup")
                            end)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -53,7 +53,7 @@ function GM:Initialize()
    self.BaseClass:Initialize()
 
    net.Start("TTT_Spectate")
-     net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool()
+     net.WriteBool(GetConVar("ttt_spectator_mode")):GetBool()
    net.SendToServer()
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -52,7 +52,9 @@ function GM:Initialize()
 
    self.BaseClass:Initialize()
 
-   RunConsoleCommand("ttt_spectate", GetConVar("ttt_spectator_mode"):GetInt())
+   net.Start("TTT_Spectate")
+     net.WriteInt(math.Clamp(GetConVar("ttt_spectator_mode"):GetInt(),0,1),2)
+   net.SendToServer()
 end
 
 function GM:InitPostEntity()
@@ -367,7 +369,10 @@ function CheckIdle()
          RunConsoleCommand("say", "(AUTOMATED MESSAGE) I have been moved to the Spectator team because I was idle/AFK.")
 
          timer.Simple(0.3, function()
-                              RunConsoleCommand("ttt_spectator_mode", 1)
+                              RunConsoleCommand("ttt_spectator_mode", 1) -- If they want to bypass it now they still can but this way they still get fspecced
+                               net.Start("TTT_Spectate")
+                                 net.WriteInt(1,2)
+                               net.SendToServer()
                               RunConsoleCommand("ttt_cl_idlepopup")
                            end)
       elseif CurTime() > (idle.t + (idle_limit / 2)) then

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -154,7 +154,7 @@ util.AddNetworkString("TTT_ShowPrints")
 util.AddNetworkString("TTT_ScanResult")
 util.AddNetworkString("TTT_FlareScorch")
 util.AddNetworkString("TTT_Radar")
-
+util.AddNetworkString("TTT_Spectate")
 ---- Round mechanics
 function GM:Initialize()
    MsgN("Trouble In Terrorist Town gamemode initializing...")

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -1,4 +1,3 @@
-
 function GetTraitors()
    local trs = {}
    for k,v in ipairs(player.GetAll()) do
@@ -180,5 +179,7 @@ local function force_spectate(ply, cmd, arg)
    end
 end
 concommand.Add("ttt_spectate", force_spectate)
-
+net.Receive("TTT_Spectate", function(l, pl)
+   force_spectate(pl, nil, {net.ReadInt(2)})
+end)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -180,6 +180,6 @@ local function force_spectate(ply, cmd, arg)
 end
 concommand.Add("ttt_spectate", force_spectate)
 net.Receive("TTT_Spectate", function(l, pl)
-   force_spectate(pl, nil, {net.ReadInt(2)})
+   force_spectate(pl, nil, { net.ReadBool() and 1 or 0 })
 end)
 


### PR DESCRIPTION
Fixes an exploit to bypass `ttt_spectator_mode` changes using the `alias` command, preventing the server from forcing you to be a spectator for being AFK. Uses net commands. Has been refined and tested (in a 4 player P2P "singleplayer" server).