### PR TITLE
TTT: Force all players to innocents on preparing

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -23,13 +23,16 @@ end
 
 function ENT:AcceptInput(name, activator)
    if name == "TestActivator" then
+      if IsValid(activator) and activator:IsPlayer() then
+         local activator_role = (GetRoundState() == ROUND_PREP) and ROLE_INNOCENT or activator:GetRole()
 
-      if IsValid(activator) and activator:IsPlayer() and (self.Role == ROLE_ANY or activator:IsRole(self.Role)) then
-         Dev(2, activator, "passed logic_role test of", self:GetName())
-         self:TriggerOutput("OnPass", activator)
-      else
-         Dev(2, activator, "failed logic_role test of", self:GetName())
-         self:TriggerOutput("OnFail", activator)
+         if self.Role == ROLE_ANY or self.Role == activator_role then
+            Dev(2, activator, "passed logic_role test of", self:GetName())
+            self:TriggerOutput("OnPass", activator)
+         else
+            Dev(2, activator, "failed logic_role test of", self:GetName())
+            self:TriggerOutput("OnFail", activator)
+         end
       end
 
       return true

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -193,11 +193,11 @@ function GM:HUDDrawTargetID()
          _, color = util.HealthToString(ent:Health())
       end
 
-      if client:IsTraitor() and GAMEMODE.round_state == ROUND_ACTIVE then
+      if client:IsTraitor() and GetRoundState() == ROUND_ACTIVE then
          target_traitor = ent:IsTraitor()
       end
 
-      target_detective = ent:IsDetective()
+      target_detective = GetRoundState() > ROUND_PREP and ent:IsDetective() or false
 
    elseif cls == "prop_ragdoll" then
       -- only show this if the ragdoll has a nick, else it could be a mattress

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -106,7 +106,7 @@ end
 CreateConVar("ttt_detective_hats", "0")
 -- Just hats right now
 local function GiveLoadoutSpecial(ply)
-   if ply:IsDetective() and GetConVar("ttt_detective_hats"):GetBool() and CanWearHat(ply) then
+   if ply:IsActiveDetective() and GetConVar("ttt_detective_hats"):GetBool() and CanWearHat(ply) then
 
       if not IsValid(ply.hat) then
          local hat = ents.Create("ttt_hat_deerstalker")


### PR DESCRIPTION
Advantage:
Traitor things can't be accessed by users that aren't traitor anymore. (Some traitor things (like rooms or secrets) are made with [ttt_logic_role](https://github.com/garrynewman/garrysmod/blob/master/garrysmod/gamemodes/terrortown/entities/entities/ttt_logic_role.lua). This entity only checks the role and not if the round is active.)

Disadvantage:
There is a very small chance that some addons could use this. But I'm not sure at the moment.
