### PR TITLE
Corrected wrong var reference 

### DIFF
--- a/garrysmod/lua/menu/mount/mount.lua
+++ b/garrysmod/lua/menu/mount/mount.lua
@@ -53,8 +53,8 @@ hook.Add( "WorkshopExtractProgress", "WorkshopExtractProgress", function( id, iI
 
 	if ( !IsValid( vgui_workshop ) ) then
 		vgui_workshop = GetOverlayPanel():Add( pnlWorkshop )
-		vgui_workshop:PrepareDownloading( id, title, expected )
-		vgui_workshop:StartDownloading( id, iImageID, title, expected )
+		vgui_workshop:PrepareDownloading( id, title, percent )
+		vgui_workshop:StartDownloading( id, iImageID, title, percent )
 	end
 
 	vgui_workshop:ExtractProgress( title, percent )


### PR DESCRIPTION
`expected` isn't defined in this case.
I'm sure that `percent` is right here.