### PR TITLE
TTT: small changes

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -36,7 +36,7 @@ end
 function RADAR:Timeout()
    self:EndScan()
 
-   if self.repeating and LocalPlayer() and (LocalPlayer():IsActiveTraitor() or LocalPlayer():IsActiveDetective()) then
+   if self.repeating and LocalPlayer() and LocalPlayer():IsActiveSpecial() and LocalPlayer():HasEquipmentItem(EQUIP_RADAR) then
       RunConsoleCommand("ttt_radar_scan")
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -230,8 +230,6 @@ function GM:InitPostEntity()
    WEPS.ForcePrecache()
 end
 
-function GM:GetGameDescription() return self.Name end
-
 -- Convar replication is broken in gmod, so we do this.
 -- I don't like it any more than you do, dear reader.
 function GM:SyncGlobals()

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -427,7 +427,7 @@ concommand.Add("ttt_order_equipment", OrderEquipment)
 
 function GM:TTTToggleDisguiser(ply, state)
    -- Can be used to prevent players from using this button.
-   -- return false to prevent it.
+   -- return true to prevent it.
 end
 
 local function SetDisguise(ply, cmd, args)
@@ -435,7 +435,7 @@ local function SetDisguise(ply, cmd, args)
 
    if ply:HasEquipmentItem(EQUIP_DISGUISE) then
       local state = #args == 1 and tobool(args[1])
-      if not hook.Run("TTTToggleDisguiser", ply, state) == false then return end
+      if hook.Run("TTTToggleDisguiser", ply, state) then return end
 
       ply:SetNWBool("disguised", state)
       LANG.Msg(ply, state and "disg_turned_on" or "disg_turned_off")


### PR DESCRIPTION
An error that could occur very rarely has been fixed. (The radar scan could be executed again shortly after the end of the round, which should not be.)
And the TTTToggleDisguiser-Hook has been modified, so it directly checks if the hook returns true.
And GM:GetGameDescription() was removed because it's defined in the [Base Gamemode](https://github.com/garrynewman/garrysmod/blob/master/garrysmod/gamemodes/base/gamemode/shared.lua#L88-L93).

(I'll squash the commits if this got approved.)