### PR TITLE
Squared velocity lengths

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -54,7 +54,7 @@ function GM:HandlePlayerDucking( ply, velocity )
 
 	if ( !ply:Crouching() ) then return false end
 
-	if ( velocity:Length2DSqr() > 0.5*0.5 ) then
+	if ( velocity:Length2DSqr() > 0.25 ) then
 		ply.CalcIdeal = ACT_MP_CROUCHWALK
 	else
 		ply.CalcIdeal = ACT_MP_CROUCH_IDLE
@@ -93,7 +93,7 @@ end
 
 function GM:HandlePlayerVaulting( ply, velocity )
 
-	if ( velocity:LengthSqr() < 1000*1000 ) then return end
+	if ( velocity:LengthSqr() < 1000000 ) then return end
 	if ( ply:IsOnGround() ) then return end
 
 	ply.CalcIdeal = ACT_MP_SWIM

--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -54,7 +54,7 @@ function GM:HandlePlayerDucking( ply, velocity )
 
 	if ( !ply:Crouching() ) then return false end
 
-	if ( velocity:Length2D() > 0.5 ) then
+	if ( velocity:Length2DSqr() > 0.5*0.5 ) then
 		ply.CalcIdeal = ACT_MP_CROUCHWALK
 	else
 		ply.CalcIdeal = ACT_MP_CROUCH_IDLE
@@ -93,7 +93,7 @@ end
 
 function GM:HandlePlayerVaulting( ply, velocity )
 
-	if ( velocity:Length() < 1000 ) then return end
+	if ( velocity:LengthSqr() < 1000*1000 ) then return end
 	if ( ply:IsOnGround() ) then return end
 
 	ply.CalcIdeal = ACT_MP_SWIM


### PR DESCRIPTION
Computing the square root of a number is expensive. By switching to LengthSqr and Length2DSqr, we skip this square-rooting altogether.

This only works for comparisons like these, since for any two numbers `x` and `y`, where `x < y`, we can assume that `x*x < y*y`.