### PR TITLE
Prevent Player:CanUseFlashlight() from returning nil

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -209,7 +209,7 @@ end
 -- Can use flashlight?
 --
 function meta:AllowFlashlight( bAble ) self.m_bFlashlight = bAble end
-function meta:CanUseFlashlight() return self.m_bFlashlight end
+function meta:CanUseFlashlight() return self.m_bFlashlight == true end
 
 -- A function to set up player hands, so coders don't have to copy all the code everytime.
 -- Call this in PlayerSpawn hook


### PR DESCRIPTION
Because Player.m_bFlashlight is nil by default, it will cause unwanted behavior in certain cases:
```Lua
-- this will be false if Player:AllowFlashlight was not called
if ( ply:CanUseFlashlight() == false ) then PlaySpookySound() end

-- this works fine
if ( ply:CanUseFlashlight() != true ) then PlaySpookySound() end
```