### PR TITLE
TTT: Fix enter button for disguiser

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -113,3 +113,10 @@ function GM:KeyRelease(ply, key)
    end
 end
 
+function GM:PlayerButtonUp(ply, btn)
+   -- Would be nice to clean up this whole "all key handling in massive
+   -- functions" thing. oh well
+   if btn == KEY_PAD_ENTER then
+      WEPS.DisguiseToggle(ply)
+   end
+end

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -405,14 +405,6 @@ function GM:KeyRelease(ply, key)
 
 end
 
-function GM:PlayerButtonUp(ply, btn)
-   -- Would be nice to clean up this whole "all key handling in massive
-   -- functions" thing. oh well
-   if btn == KEY_PAD_ENTER then
-      WEPS.DisguiseToggle(ply)
-   end
-end
-
 -- Normally all dead players are blocked from IN_USE on the server, meaning we
 -- can't let them search bodies. This sucks because searching bodies is
 -- fun. Hence on the client we override +use for specs and use this instead.


### PR DESCRIPTION
Calling `WEPS.DisguiseToggle(ply)` in server state doesn't make any sense.
It has to be client side.