### PR TITLE
Fixed endroundtimer not stopping when forcing roundrestart

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -418,7 +418,7 @@ local function StopRoundTimers()
    -- remove all timers
    timer.Stop("wait2prep")
    timer.Stop("prep2begin")
-   timer.Stop("end2begin")
+   timer.Stop("end2prep")
    timer.Stop("winchecker")
 end
 


### PR DESCRIPTION
I always wondered why the round was restarting twice when forcing roundrestart post round.