### PR TITLE
TTT: Error Fix

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -269,7 +269,7 @@ local function DropActiveAmmo(ply)
    ply:AnimPerformGesture(ACT_ITEM_GIVE)
 
    local box = ents.Create(wep.AmmoEnt)
-   if not IsValid(box) then box:Remove() end
+   if not IsValid(box) then return end
 
    box:SetPos(pos + dir)
    box:SetOwner(ply)


### PR DESCRIPTION
This prevents errors like:
```
[ERROR] gamemodes/terrortown/gamemode/weaponry.lua:272: Tried to use a NULL entity!
  1. Remove - [C]:-1
   2. unknown - gamemodes/terrortown/gamemode/weaponry.lua:272
    3. unknown - lua/includes/modules/concommand.lua:54
```
Because invalid entities are not removeable with `Entity:Remove()`.