### PR TITLE
TTT: Added check if player can carry loadout weps

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -59,7 +59,7 @@ local function GiveLoadoutWeapons(ply)
    if not weps then return end
 
    for _, cls in pairs(weps) do
-      if not ply:HasWeapon(cls) then
+      if not ply:HasWeapon(cls) and ply:CanCarryWeapon(WEPS.TypeForWeapon(cls)) then
          ply:Give(cls)
       end
    end
@@ -74,7 +74,7 @@ local function HasLoadoutWeapons(ply)
 
 
    for _, cls in pairs(weps) do
-      if not ply:HasWeapon(cls) then
+      if not ply:HasWeapon(cls) and ply:CanCarryWeapon(WEPS.TypeForWeapon(cls)) then
          return false
       end
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -59,7 +59,7 @@ local function GiveLoadoutWeapons(ply)
    if not weps then return end
 
    for _, cls in pairs(weps) do
-      if not ply:HasWeapon(cls) and ply:CanCarryWeapon(WEPS.TypeForWeapon(cls)) then
+      if not ply:HasWeapon(cls) and ply:CanCarryType(WEPS.TypeForWeapon(cls)) then
          ply:Give(cls)
       end
    end
@@ -74,7 +74,7 @@ local function HasLoadoutWeapons(ply)
 
 
    for _, cls in pairs(weps) do
-      if not ply:HasWeapon(cls) and ply:CanCarryWeapon(WEPS.TypeForWeapon(cls)) then
+      if not ply:HasWeapon(cls) and ply:CanCarryType(WEPS.TypeForWeapon(cls)) then
          return false
       end
    end


### PR DESCRIPTION
This check can prevent problems with addons that loadouts give to players.
It could cause problems with addons, such as Pointshop 2, Power Rounds, or similiar.
If, for example, you get a special crowbar through a Pointshop, TTT would try to give it the original one. If you were a detective, you would have endless DNA scanners as they are automatically supplemented.