### PR TITLE
Add an option to disable halo on physgun unfreeze

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/init.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/init.lua
@@ -140,6 +140,8 @@ end
 -----------------------------------------------------------]]
 function GM:PlayerUnfrozeObject( ply, entity, physobject )
 
+	if ( DisablePropCreateEffect ) then return end
+	
 	local effectdata = EffectData()
 		effectdata:SetOrigin( physobject:GetPos() )
 		effectdata:SetEntity( entity )


### PR DESCRIPTION
I need this because the material on my SENT is not rendering properly with these halos