### PR TITLE
TTT: Fix Error?

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -653,7 +653,7 @@ end
 local speaker = surface.GetTextureID("voice/icntlk_sv")
 function VOICE.Draw(client)
    local b = client.voice_battery
-   if b >= battery_max then return end
+   if not b or b >= battery_max then return end
 
    local x = 25
    local y = 10


### PR DESCRIPTION
```
[ERROR] gamemodes/terrortown/gamemode/cl_voice.lua:656: attempt to compare number with nil
  1. Draw - gamemodes/terrortown/gamemode/cl_voice.lua:656
   2. unknown - gamemodes/terrortown/gamemode/cl_hud.lua:350
```
I'm not sure why `client.voice_battery` becomes nil.
But I am very sure that it was not an addon.
This solution may not be the best. Rather, it would be better to know why `client.voice_battery` was nil.