### PR TITLE
Fixed string.NiceTime

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -209,12 +209,12 @@ function string.NiceTime( seconds )
 		return t .. pluralizeString( " day", t )
 	end
 
-	if ( seconds < 60 * 60 * 24 * 7 * 52 ) then
+	if ( seconds < 60 * 60 * 24 * 365 ) then
 		local t = math.floor( seconds / ( 60 * 60 * 24 * 7 ) )
 		return t .. pluralizeString( " week", t )
 	end
 
-	local t = math.floor( seconds / ( 60 * 60 * 24 * 7 * 52 ) )
+	local t = math.floor( seconds / ( 60 * 60 * 24 * 365 ) )
 	return t .. pluralizeString( " year", t )
 
 end


### PR DESCRIPTION
Method for calculation length of the year "60 * 60 * 24 * 7 * 52" replaced with "60 * 60 * 24 * 365", because 7*52 is 364.