### PR TITLE
TTT: Call PlayerLoadout as hook

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -170,8 +170,8 @@ function GM:PlayerLoadout( ply )
 end
 
 function GM:UpdatePlayerLoadouts()
-   for k, v in pairs(player.GetAll()) do
-      GAMEMODE:PlayerLoadout(v)
+   for _, ply in ipairs(player.GetAll()) do
+      hook.Call("PlayerLoadout", GAMEMODE, ply)
    end
 end
 


### PR DESCRIPTION
Useful for addons that want to block loadouts or something like this.
But maybe not necessary.