### PR TITLE
TTT: Fixed some cases where Player:Alive() isn't equal to Player:IsTraitor()

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -521,8 +521,9 @@ function IncRoundEnd(incr)
 end
 
 function TellTraitorsAboutTraitors()
+   local plys = player.GetAll()
    local traitornicks = {}
-   for k,v in pairs(player.GetAll()) do
+   for k,v in ipairs(plys) do
       if v:IsTraitor() then
          table.insert(traitornicks, v:Nick())
       end
@@ -530,14 +531,14 @@ function TellTraitorsAboutTraitors()
 
    -- This is ugly as hell, but it's kinda nice to filter out the names of the
    -- traitors themselves in the messages to them
-   for k,v in pairs(player.GetAll()) do
+   for k,v in ipairs(plys) do
       if v:IsTraitor() then
          if #traitornicks < 2 then
             LANG.Msg(v, "round_traitors_one")
             return
          else
             local names = ""
-            for i,name in pairs(traitornicks) do
+            for i, name in ipairs(traitornicks) do
                if name != v:Nick() then
                   names = names .. name .. ", "
                end
@@ -557,7 +558,7 @@ function SpawnWillingPlayers(dead_only)
    -- simple method, should make this a case of the other method once that has
    -- been tested.
    if wave_delay <= 0 or dead_only then
-      for k, ply in pairs(player.GetAll()) do
+      for k, ply in ipairs(plys) do
          if IsValid(ply) then
             ply:SpawnForRound(dead_only)
          end
@@ -570,7 +571,6 @@ function SpawnWillingPlayers(dead_only)
       for _, ply in RandomPairs(plys) do
          if IsValid(ply) and ply:ShouldSpawn() then
             table.insert(to_spawn, ply)
-            GAMEMODE:PlayerSpawnAsSpectator(ply)
          end
       end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -75,6 +75,7 @@ function GM:PlayerSpawn(ply)
 
    if ply:IsSpec() then
       ply:StripAll()
+      ply:KillSilent()
       ply:Spectate(OBS_MODE_ROAMING)
       return
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -12,7 +12,7 @@ function plymeta:SetRagdollSpec(s)
 end
 function plymeta:GetRagdollSpec() return self.spec_ragdoll end
 
-AccessorFunc(plymeta, "force_spec", "ForceSpec", FORCE_BOOL)
+function plymeta:SetForceSpec(state) self:SetNWBool("force_spec", state) end
 
 --- Karma
 

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -52,6 +52,8 @@ end
 
 function plymeta:GetBaseKarma() return self:GetNWFloat("karma", 1000) end
 
+function plymeta:GetForceSpec() return self:GetNWBool("force_spec", false) end
+
 function plymeta:HasEquipmentWeapon()
    for _, wep in pairs(self:GetWeapons()) do
       if IsValid(wep) and wep:IsEquipment() then

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -163,7 +163,6 @@ local function force_spectate(ply, cmd, arg)
             ply:Kill()
          end
 
-         GAMEMODE:PlayerSpawnAsSpectator(ply)
          ply:SetTeam(TEAM_SPEC)
          ply:SetForceSpec(true)
          ply:Spawn()
@@ -176,4 +175,3 @@ concommand.Add("ttt_spectate", force_spectate)
 net.Receive("TTT_Spectate", function(l, pl)
    force_spectate(pl, nil, { net.ReadBool() and 1 or 0 })
 end)
-

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -58,14 +58,14 @@ end
 function ScoreGroup(p)
    if not IsValid(p) then return -1 end -- will not match any group panel
 
-   local group = hook.Call( "TTTScoreGroup", nil, p )
+   local group = hook.Call("TTTScoreGroup", nil, p)
 
    if group then -- If that hook gave us a group, use it
       return group
    end
 
    if DetectiveMode() then
-      if p:IsSpec() and (not p:Alive()) then
+      if p:IsSpec() and (not p:Alive()) and (not p:GetForceSpec()) then
          if p:GetNWBool("body_found", false) then
             return GROUP_FOUND
          else


### PR DESCRIPTION
- Some small micro optimizations.
- Removed useless GAMEMODE:PlayerSpawnAsSpectator(ply)
- Use Player:KillSilent() to prevent Player:Alive() from returning a different result than that of Player:IsTraitor().
- Moved Player:GetForceSpec() shared by networking force_spec.
- Fixed a problem at ScoreGroup() that is caused because Player:Alive() now has the same result like Player:IsTraitor().

I hope you like my great English. And yes, the text may be full of mistakes.

What about breaking other Addons?
It could be that an addon is broken by these changes. But there are also a few addons which would work because these changes.
I doubt that Addons will override Get/SetForceSpec. I don't know if there are people that are stupid enough to use Player.force_spec instead of Player:Get/SetForceSpec.