### PR TITLE
Removed CAP_INNATE_RANGE_ATTACK1 from weapon_base

### DIFF
--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/init.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/init.lua
@@ -86,7 +86,7 @@ end
 -----------------------------------------------------------]]
 function SWEP:GetCapabilities()
 
-	return bit.bor( CAP_WEAPON_RANGE_ATTACK1, CAP_INNATE_RANGE_ATTACK1 )
+	return CAP_WEAPON_RANGE_ATTACK1
 
 end
 


### PR DESCRIPTION
CAP_INNATE_RANGE_ATTACK1/2 is a flag for NPCs to fire without having a valid weapon -- this shouldn't apply to the weapon, itself.