### PR TITLE
Block evil deceptive servers

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -239,7 +239,8 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	
 	// These servers use naughty tricks to be at the top of the list, let's shove them to the bottom.
 	var lowername = data.name.toLowerCase();
-	if ( lowername.search("superiorservers") >= 0 || lowername.search("superior servers") >= 0 ) data.recommended += 999;
+	var sup = lowername.search("superior");
+	if ( if sup >= 0 && sup < lowername.search("servers") ) data.recommended += 999;
 	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -247,6 +247,10 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	var divi = lowername.search("divinity");
 	if ( divi >= 0 && divi < lowername.search("roleplay") ) data.recommended += 999;
 	
+	//UrbanGamers.net
+	var urban = lowername.search("urban");
+	if ( urban >= 0 && urban < lowername.search("Gamers") ) data.recommended += 999;
+	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;
 	if ( data.players >= 32 ) data.recommended -= 20;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -236,7 +236,10 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
-
+	
+	// These servers use naughty tricks to be at the top of the list, let's shove them to the bottom.
+	if ( data.name.toLowerCase().search("superiorservers.co") >= 0 ) data.recommended += 999;
+	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;
 	if ( data.players >= 32 ) data.recommended -= 20;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -238,7 +238,8 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
 	
 	// These servers use naughty tricks to be at the top of the list, let's shove them to the bottom.
-	if ( data.name.toLowerCase().search("superiorservers.co") >= 0 ) data.recommended += 999;
+	var lowername = data.name.toLowerCase();
+	if ( lowername.search("superiorservers") >= 0 || lowername.search("superior servers") >= 0 ) data.recommended += 999;
 	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -239,8 +239,13 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	
 	// These servers use naughty tricks to be at the top of the list, let's shove them to the bottom.
 	var lowername = data.name.toLowerCase();
+	//SuperiorServers.co
 	var sup = lowername.search("superior");
 	if ( sup >= 0 && sup < lowername.search("servers") ) data.recommended += 999;
+	
+	//DivinityRoleplay.net
+	var divi = lowername.search("divinity");
+	if ( divi >= 0 && divi < lowername.search("roleplay") ) data.recommended += 999;
 	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -249,7 +249,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	
 	//UrbanGamers.net
 	var urban = lowername.search("urban");
-	if ( urban >= 0 && urban < lowername.search("Gamers") ) data.recommended += 999;
+	if ( urban >= 0 && urban < lowername.search("gamers") ) data.recommended += 999;
 	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -240,7 +240,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	// These servers use naughty tricks to be at the top of the list, let's shove them to the bottom.
 	var lowername = data.name.toLowerCase();
 	var sup = lowername.search("superior");
-	if ( if sup >= 0 && sup < lowername.search("servers") ) data.recommended += 999;
+	if ( sup >= 0 && sup < lowername.search("servers") ) data.recommended += 999;
 	
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
 	if ( data.players >= 16 ) data.recommended -= 40;


### PR DESCRIPTION
As we all know, SuperiorServers.co uses redirect servers, which tricks players into thinking that they would have low ping joining the server, when they will have lots of it. StonedPenguin promised multiple times to stop, but still continues this practice to this day. It's time to take action by putting his servers on the bottom of the list where it belongs.