### PR TITLE
TTT: `phys_swap` pulls out magneto stick.

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -90,6 +90,8 @@ function GM:PlayerBindPress(ply, bind, pressed)
    elseif (bind == "gmod_undo" or bind == "undo") and pressed then
       RunConsoleCommand("ttt_dropammo")
       return true
+   elseif bind == "phys_swap" and pressed then
+      RunConsoleCommand("ttt_quickslot", "5")
    end
 end
 


### PR DESCRIPTION
For newer and older players who are familiar with sandbox mode or the Half Life series, for the magneto stick is the direct replacement for the physics gun in this gamemode.