### PR TITLE
[TTT] Falldamage not handled correct

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -792,7 +792,7 @@ end
 -- rather high drop already. Hence we do our own fall damage handling in
 -- OnPlayerHitGround.
 function GM:GetFallDamage(ply, speed)
-   return 1
+   return 0
 end
 
 local fallsounds = {


### PR DESCRIPTION
GM:OnPlayerHitGround handles fall damage already, why should we get 2 damage entrys in the damage log by adding one more damage?