### PR TITLE
TTT: Remove version

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -161,7 +161,6 @@ util.AddNetworkString("TTT_Spectate")
 ---- Round mechanics
 function GM:Initialize()
    MsgN("Trouble In Terrorist Town gamemode initializing...")
-   ShowVersion()
 
    -- Force friendly fire to be enabled. If it is off, we do not get lag compensation.
    RunConsoleCommand("mp_friendlyfire", "1")
@@ -637,8 +636,6 @@ function BeginRound()
 
    if CheckForAbort() then return end
 
-   AnnounceVersion()
-
    InitRoundEndTime()
 
    if CheckForAbort() then return end
@@ -960,25 +957,3 @@ local function ForceRoundRestart(ply, command, args)
    end
 end
 concommand.Add("ttt_roundrestart", ForceRoundRestart)
-
--- Version announce also used in Initialize
-function ShowVersion(ply)
-   local text = Format("This is TTT version %s\n", GAMEMODE.Version)
-   if IsValid(ply) then
-      ply:PrintMessage(HUD_PRINTNOTIFY, text)
-   else
-      Msg(text)
-   end
-end
-concommand.Add("ttt_version", ShowVersion)
-
-function AnnounceVersion()
-   local text = Format("You are playing %s, version %s.\n", GAMEMODE.Name, GAMEMODE.Version)
-
-   -- announce to players
-   for k, ply in pairs(player.GetAll()) do
-      if IsValid(ply) then
-         ply:PrintMessage(HUD_PRINTTALK, text)
-      end
-   end
-end

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -2,11 +2,6 @@ GM.Name = "Trouble in Terrorist Town"
 GM.Author = "Bad King Urgrain"
 GM.Email = "thegreenbunny@gmail.com"
 GM.Website = "ttt.badking.net"
--- Date of latest changes (YYYY-MM-DD)
-GM.Version = "2016-04-20"
-
-
-GM.Customized = false
 
 -- Round status consts
 ROUND_WAIT   = 1
@@ -65,10 +60,10 @@ OPEN_BUT  = 3
 OPEN_NOTOGGLE = 4 --movelinear
 
 -- Mute types
-MUTE_NONE = 0
+MUTE_NONE   = 0
 MUTE_TERROR = 1
-MUTE_ALL = 2
-MUTE_SPEC = 1002
+MUTE_ALL    = 2
+MUTE_SPEC   = 1002
 
 COLOR_WHITE  = Color(255, 255, 255, 255)
 COLOR_BLACK  = Color(0, 0, 0, 255)


### PR DESCRIPTION
There is no reason that TTT has his own version system.
Nobody really cares about it.
Nobody updates the version.
Nobody reads it.
Trust me.

Either we remove the version completely, or we use the version of GMod.
(If you want the first option: Should I remove [these](https://github.com/markusmarkusz/garrysmod/blob/patch-2/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua#L1042) versions too?)