### PR TITLE
Let clients decide if they want to see custom loading screens

### DIFF
--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -12,6 +12,7 @@ g_ServerURL		= ""
 g_MaxPlayers	= ""
 g_SteamID		= ""
 
+local showloadingurl = CreateClientConVar( "cl_showloadingurl", "1", true, false, "Show custom loading screens" )
 local PANEL = {}
 
 --[[---------------------------------------------------------
@@ -25,7 +26,10 @@ end
 
 
 function PANEL:ShowURL( url, force )
-
+	if force and not showloadingurl:GetBool() then
+		return;
+	end
+	
 	if ( string.len( url ) < 5 ) then
 		return;
 	end


### PR DESCRIPTION
Let clients decide if they should see custom loading screens for servers or if they should just see the standard loading screen.