### PR TITLE
Removed a critically important unmeant "local" operator

### DIFF
--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -101,9 +101,9 @@ function GetHovered( eyepos, eyevec )
 		filter = filter
 	} )
 
-	// Hit COLLISION_GROUP_DEBRIS and stuff
+	-- Hit COLLISION_GROUP_DEBRIS and stuff
 	if ( !trace.Hit || !IsValid( trace.Entity ) ) then
-		local trace = util.TraceLine( {
+		trace = util.TraceLine( {
 			start = eyepos,
 			endpos = eyepos + eyevec * 1024,
 			filter = filter,


### PR DESCRIPTION
Considering on the comment, the **outer** "trace" variable should be overwritten if we perform the new trace, since we're checking it further. **Otherwise this whole block of code is useless.**