### PR TITLE
Javascript "Cannot set property" bug

### DIFF
--- a/garrysmod/html/js/menu/control.NewGame.js
+++ b/garrysmod/html/js/menu/control.NewGame.js
@@ -221,7 +221,9 @@ function ControllerNewGame( $scope, $element, $rootScope, $location, $filter )
 		oldSvLan = $scope.ServerSettings.sv_lan;
 		
 		if ( !$scope.ServerSettings.p2p_enabled ) {
-			document.getElementById("p2p_friendsonly").disabled = true;
+			if (document.getElementById("p2p_friendsonly") !== null) {
+				document.getElementById("p2p_friendsonly").disabled = true;
+			}
 			$scope.ServerSettings.p2p_friendsonly = false;
 			UpdateDigest( $scope, 50 );
 		} else {


### PR DESCRIPTION
PR: Check if the javascript element `p2p_friendsonly` exists before changing disabled value.

The bug:
When selecting the checkbox "Local server" and pressing the button "Start game" the script fails because it can't find the ID `p2p_friendsonly`. No impacts seen, only this message in console:
```
[HTML] TypeError: Cannot set property 'disabled' of null
    at Object.CheckboxCheck (asset://garrysmod/html/js/menu/control.NewGame.js:228:56)
    at Object.get (asset://garrysmod/html/js/thirdparty/angular.js:70:430)
    at Object.$digest (asset://garrysmod/html/js/thirdparty/angular.js:85:53)
    at asset://garrysmod/html/js/menu/menuApp.js?2:25:9
	
[HTML] TypeError: Cannot set property 'disabled' of null
    at Object.CheckboxCheck (asset://garrysmod/html/js/menu/control.NewGame.js:228:56)
    at Object.get (asset://garrysmod/html/js/thirdparty/angular.js:70:430)
    at Object.$digest (asset://garrysmod/html/js/thirdparty/angular.js:85:53)
    at asset://garrysmod/html/js/menu/menuApp.js?2:25:9
```

I'm on Windows, tested on live and dev branch.

PS: ~~Please update the "Next Update" links in README.md and GitHub Wiki (I think it's not worth a PR)~~ Thanks.