### PR TITLE
Add global function Print

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -90,6 +90,20 @@ function PrintTable( t, indent, done )
 end
 
 --[[---------------------------------------------------------
+	Either print or PrintTable, depending on the arguments
+-----------------------------------------------------------]]
+function Print(...)
+	if select("#", ...) == 1	-- only 1 element
+		and type(...) == "table"	-- which is a table
+		and (getmetatable(...) == nil or not debug.getmetatable(...).__tostring)	-- that has no custom tostring function
+	then
+		PrintTable(...)
+	else
+		print(...)
+	end
+end
+
+--[[---------------------------------------------------------
 	Returns a random vector
 -----------------------------------------------------------]]
 function VectorRand()


### PR DESCRIPTION
Print behaves like PrintTable for tables, and like print for all other cases. Very useful for debugging, especially with lua_run and lua_run_cl, where I constantly find myself switching back and forth between print and PrintTable.