### PR TITLE
Added player.GetByAccountID( number AccountID )

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -88,6 +88,20 @@ function player.GetBySteamID64( ID )
 
 end
 
+function player.GetByAccountID( ID )
+
+	for _, pl in pairs( player.GetAll() ) do
+
+		if ( pl:AccountID() == ID ) then
+			return pl
+		end
+
+	end
+
+	return false
+
+end
+
 --[[---------------------------------------------------------
 	Name: DebugInfo
 	Desc: Prints debug information for the player


### PR DESCRIPTION
In some cases this function is more optimal to use since you compare numbers instead of strings when iterating through players.